### PR TITLE
Update vscode/test-electron import

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,7 +16,7 @@
 
 import * as path from "path";
 
-import { runTests } from "vscode-test";
+import { runTests } from "@vscode/test-electron";
 
 async function main() {
   try {


### PR DESCRIPTION
## Describe the problem this PR is solving
Fixes the vscode/test-electron import used to run tests.

- Closes #74 

## Short description of the changes
- Fix import to use "@vscode/test-electron"