### PR TITLE
Add support for creating and removing Scopes & Collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "axios": "^0.21.4",
-        "couchbase": "^3.2.5",
+        "couchbase": "^3.2.6",
         "keytar": "^7.7.0"
       },
       "devDependencies": {
@@ -1628,16 +1628,16 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/couchbase": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-3.2.5.tgz",
-      "integrity": "sha512-oXcW9UI6rBxRwzOIzJ1yWpR8Vka0x2neXT9SHuHDNR3JqWnFSmf2WezjjqsVVZDk1DmBA2R9cGX7e67fkpkEvg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-3.2.6.tgz",
+      "integrity": "sha512-m2tjRdGggvAuK1UjK4qeWNsxfZ6Uon3cnFdyZVTtmvIGdoU7vUgICDbj9EdvsMTmqGHvczcPsaITTorsFVXMBQ==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "debug": "^4.3.4",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "parse-duration": "^1.0.2",
-        "prebuild-install": "^7.0.1"
+        "prebuild-install": "^7.1.1"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -3495,9 +3495,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -3760,9 +3760,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4016,9 +4016,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/nanoid": {
       "version": "3.3.1",
@@ -7504,15 +7504,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "couchbase": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-3.2.5.tgz",
-      "integrity": "sha512-oXcW9UI6rBxRwzOIzJ1yWpR8Vka0x2neXT9SHuHDNR3JqWnFSmf2WezjjqsVVZDk1DmBA2R9cGX7e67fkpkEvg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/couchbase/-/couchbase-3.2.6.tgz",
+      "integrity": "sha512-m2tjRdGggvAuK1UjK4qeWNsxfZ6Uon3cnFdyZVTtmvIGdoU7vUgICDbj9EdvsMTmqGHvczcPsaITTorsFVXMBQ==",
       "requires": {
         "bindings": "^1.5.0",
         "debug": "^4.3.4",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "parse-duration": "^1.0.2",
-        "prebuild-install": "^7.0.1"
+        "prebuild-install": "^7.1.1"
       },
       "dependencies": {
         "debug": {
@@ -8883,9 +8883,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -9085,9 +9085,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -9282,9 +9282,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "nanoid": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "onCommand:vscode-couchbase.refreshCollection",
     "onCommand:vscode-couchbase.createScope",
     "onCommand:vscode-couchbase.removeScope",
+    "onCommand:vscode-couchbase.refreshScopes",
     "onCommand:vscode-couchbase.createCollection",
     "onCommand:vscode-couchbase.removeCollection",
+    "onCommand:vscode-couchbase.refreshCollections",
     "onCustomEditor:vscode-couchbase.couchbaseDocument",
     "onStartupFinished",
     "onView:couchbase-activity-bar"
@@ -342,7 +344,7 @@
       },
       {
         "command": "vscode-couchbase.refreshCollection",
-        "title": "Refresh Collection",
+        "title": "Refresh Documents",
         "category": "Couchbase"
       },
       {
@@ -356,6 +358,11 @@
         "category": "Couchbase"
       },
       {
+        "command": "vscode-couchbase.refreshScopes",
+        "title": "Refresh Scopes",
+        "category": "Couchbase"
+      },
+      {
         "command": "vscode-couchbase.createCollection",
         "title": "Create Collection",
         "category": "Couchbase"
@@ -363,6 +370,11 @@
       {
         "command": "vscode-couchbase.removeCollection",
         "title": "Remove Collection",
+        "category": "Couchbase"
+      },
+      {
+        "command": "vscode-couchbase.refreshCollections",
+        "title": "Refresh Collections",
         "category": "Couchbase"
       }
     ],
@@ -436,12 +448,20 @@
           "when": "view == couchbase && viewItem == scope"
         },
         {
+          "command": "vscode-couchbase.refreshScopes",
+          "when": "view == couchbase && viewItem == bucket"
+        },
+        {
           "command": "vscode-couchbase.createCollection",
           "when": "view == couchbase && viewItem == scope"
         },
         {
           "command": "vscode-couchbase.removeCollection",
           "when": "view == couchbase && viewItem == collection"
+        },
+        {
+          "command": "vscode-couchbase.refreshCollections",
+          "when": "view == couchbase && viewItem == scope"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "onCommand:vscode-couchbase.refreshCollection",
     "onCommand:vscode-couchbase.createScope",
     "onCommand:vscode-couchbase.removeScope",
+    "onCommand:vscode-couchbase.createCollection",
+    "onCommand:vscode-couchbase.removeCollection",
     "onCustomEditor:vscode-couchbase.couchbaseDocument",
     "onStartupFinished",
     "onView:couchbase-activity-bar"
@@ -352,6 +354,16 @@
         "command": "vscode-couchbase.removeScope",
         "title": "Remove Scope",
         "category": "Couchbase"
+      },
+      {
+        "command": "vscode-couchbase.createCollection",
+        "title": "Create Collection",
+        "category": "Couchbase"
+      },
+      {
+        "command": "vscode-couchbase.removeCollection",
+        "title": "Remove Collection",
+        "category": "Couchbase"
       }
     ],
     "menus": {
@@ -422,6 +434,14 @@
         {
           "command": "vscode-couchbase.removeScope",
           "when": "view == couchbase && viewItem == scope"
+        },
+        {
+          "command": "vscode-couchbase.createCollection",
+          "when": "view == couchbase && viewItem == scope"
+        },
+        {
+          "command": "vscode-couchbase.removeCollection",
+          "when": "view == couchbase && viewItem == collection"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
-    "couchbase": "^3.2.5",
+    "couchbase": "^3.2.6",
     "keytar": "^7.7.0"
   },
   "activationEvents": [
@@ -98,7 +98,7 @@
         "language": "typescript",
         "path": "./snippets/ts/subdocops.json"
       },
-      { 
+      {
         "language": "typescript",
         "path": "./snippets/ts/query.json"
       },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "onCommand:vscode-couchbase.createDocument",
     "onCommand:vscode-couchbase.removeDocument",
     "onCommand:vscode-couchbase.refreshCollection",
+    "onCommand:vscode-couchbase.createScope",
+    "onCommand:vscode-couchbase.removeScope",
     "onCustomEditor:vscode-couchbase.couchbaseDocument",
     "onStartupFinished",
     "onView:couchbase-activity-bar"
@@ -340,6 +342,16 @@
         "command": "vscode-couchbase.refreshCollection",
         "title": "Refresh Collection",
         "category": "Couchbase"
+      },
+      {
+        "command": "vscode-couchbase.createScope",
+        "title": "Create Scope",
+        "category": "Couchbase"
+      },
+      {
+        "command": "vscode-couchbase.removeScope",
+        "title": "Remove Scope",
+        "category": "Couchbase"
       }
     ],
     "menus": {
@@ -402,6 +414,14 @@
         {
           "command": "vscode-couchbase.refreshCollection",
           "when": "view == couchbase && viewItem == collection"
+        },
+        {
+          "command": "vscode-couchbase.createScope",
+          "when": "view == couchbase && viewItem == bucket"
+        },
+        {
+          "command": "vscode-couchbase.removeScope",
+          "when": "view == couchbase && viewItem == scope"
         }
       ],
       "view/title": [

--- a/scripts/rebuildElectron.js
+++ b/scripts/rebuildElectron.js
@@ -25,7 +25,7 @@ Promise.resolve()
   .then(_ => {
     return rebuild({
       buildPath: ROOT_DIR,
-      electronVersion: '18.3.5'
+      electronVersion: '19.0.7'
     });
   })
   .then(_ => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -290,7 +290,7 @@ export function activate(context: vscode.ExtensionContext) {
           .collections();
         await collectionManager?.createScope(scopeName);
 
-        clusterConnectionTreeProvider.refresh();
+        clusterConnectionTreeProvider.refresh(node);
       }
     )
   );
@@ -350,7 +350,7 @@ export function activate(context: vscode.ExtensionContext) {
           scopeName: node.scopeName,
         });
 
-        clusterConnectionTreeProvider.refresh();
+        clusterConnectionTreeProvider.refresh(node);
       }
     )
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -324,6 +324,15 @@ export function activate(context: vscode.ExtensionContext) {
 
   subscriptions.push(
     vscode.commands.registerCommand(
+      "vscode-couchbase.refreshScopes",
+      async (node: BucketNode) => {
+        clusterConnectionTreeProvider.refresh(node);
+      }
+    )
+  );
+
+  subscriptions.push(
+    vscode.commands.registerCommand(
       "vscode-couchbase.createCollection",
       async (node: ScopeNode) => {
         const connection = Memory.state.get<IConnection>("activeConnection");
@@ -381,6 +390,15 @@ export function activate(context: vscode.ExtensionContext) {
         );
 
         clusterConnectionTreeProvider.refresh();
+      }
+    )
+  );
+
+  subscriptions.push(
+    vscode.commands.registerCommand(
+      "vscode-couchbase.refreshCollections",
+      async (node: ScopeNode) => {
+        clusterConnectionTreeProvider.refresh(node);
       }
     )
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ export function activate(context: vscode.ExtensionContext) {
             .upsert(name, JSON.parse(document.getText()));
           vscode.window.setStatusBarMessage("Document saved", 2000);
 
-          // TODO: refresh collection to show new docs
+          clusterConnectionTreeProvider.refresh();
         }
       }
     )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,7 +247,7 @@ export function activate(context: vscode.ExtensionContext) {
         memFs.delete(uri);
 
         // TODO: refresh collection
-      };
+      }
     )
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,7 +246,7 @@ export function activate(context: vscode.ExtensionContext) {
         );
         memFs.delete(uri);
 
-        // TODO: refresh collection
+        clusterConnectionTreeProvider.refresh();
       }
     )
   );

--- a/src/model/BucketNode.ts
+++ b/src/model/BucketNode.ts
@@ -22,21 +22,33 @@ import { ScopeSpec } from "couchbase";
 
 export class BucketNode implements INode {
   constructor(
-    private readonly connection: IConnection,
-    private readonly bucket: string,
-    private readonly isScopesandCollections: boolean,
+    public readonly connection: IConnection,
+    public readonly bucketName: string,
+    public readonly isScopesandCollections: boolean,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState
   ) {}
 
   public getTreeItem(): vscode.TreeItem {
     return {
-      label: `${this.bucket}`,
+      label: `${this.bucketName}`,
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
       contextValue: "bucket",
       iconPath: {
-        light: path.join(__filename, "..", "..", "images/light", "bucket-icon.svg"),
-        dark: path.join(__filename, "..", "..", "images/dark", "bucket-icon.svg"),
-      } 
+        light: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/light",
+          "bucket-icon.svg"
+        ),
+        dark: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/dark",
+          "bucket-icon.svg"
+        ),
+      },
     };
   }
 
@@ -44,15 +56,20 @@ export class BucketNode implements INode {
     const nodes: INode[] = [];
     if (this.isScopesandCollections) {
       try {
-        let scopes = await this.connection.cluster?.bucket(this.bucket).collections().getAllScopes();
+        let scopes = await this.connection.cluster
+          ?.bucket(this.bucketName)
+          .collections()
+          .getAllScopes();
         scopes?.forEach((scope: ScopeSpec) => {
-          nodes.push(new ScopeNode(
-            this.connection,
-            scope.name,
-            this.bucket,
-            scope.collections,
-            vscode.TreeItemCollapsibleState.None
-          ));
+          nodes.push(
+            new ScopeNode(
+              this.connection,
+              scope.name,
+              this.bucketName,
+              scope.collections,
+              vscode.TreeItemCollapsibleState.None
+            )
+          );
         });
       } catch (err: any) {
         console.log(err);

--- a/src/model/ScopeNode.ts
+++ b/src/model/ScopeNode.ts
@@ -21,10 +21,10 @@ import CollectionNode from "./CollectionNode";
 
 export class ScopeNode implements INode {
   constructor(
-    private readonly connection: IConnection,
-    private readonly scopeName: string,
-    private readonly bucketName: string,
-    private readonly collections: any[],
+    public readonly connection: IConnection,
+    public readonly scopeName: string,
+    public readonly bucketName: string,
+    public readonly collections: any[],
     public readonly collapsibleState: vscode.TreeItemCollapsibleState
   ) {}
 
@@ -34,9 +34,21 @@ export class ScopeNode implements INode {
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
       contextValue: "scope",
       iconPath: {
-        light: path.join(__filename, "..", "..", "images/light", "scopes-icon.svg"),
-        dark: path.join(__filename, "..", "..", "images/dark", "scopes-icon.svg"),
-      }
+        light: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/light",
+          "scopes-icon.svg"
+        ),
+        dark: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/dark",
+          "scopes-icon.svg"
+        ),
+      },
     };
   }
 
@@ -45,7 +57,9 @@ export class ScopeNode implements INode {
 
     for (const collection of this.collections) {
       try {
-        const queryResult = await this.connection.cluster?.query(`select count(1) as count from \`${this.bucketName}\`.\`${this.scopeName}\`.\`${collection.name}\`;`);
+        const queryResult = await this.connection.cluster?.query(
+          `select count(1) as count from \`${this.bucketName}\`.\`${this.scopeName}\`.\`${collection.name}\`;`
+        );
         const count = queryResult?.rows[0].count;
 
         const collectionTreeItem = new CollectionNode(


### PR DESCRIPTION
## Describe the problem this PR is solving
Add support for creating and removing scopes and collections. The commands are available via the tree view when right-clicking on the appropriate item.

eg bucket can create scopes, scopes can create collections

- Closes #21 
- Closes #23 
- Closes #24 
- Closes #26

## Short description of the changes
- Adds new create scope, create collection, remove scope and remove scope commands
- Wires up new commands into context menus