### PR TITLE
Use couchbase scheme prefix when creating connections

### DIFF
--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -79,7 +79,7 @@ export async function addConnection() {
     prompt: "Enter Cluter Connection URL",
     placeHolder: "URL",
     ignoreFocusOut: true,
-    value: "http://127.0.0.1:8091",
+    value: "couchbase://localhost",
   });
   if (!url) {
     vscode.window.showErrorMessage('Cluster URL is required.');


### PR DESCRIPTION
## Describe the problem this PR is solving
Use the `couchbase://` scheme to connect to Couchbase clusters.

## Short description of the changes
- Use `couchbase://` as the example cluster scheme when creating a new 
