### PR TITLE
Pass parent node as constructor argument to other nodes

### DIFF
--- a/src/model/BucketNode.ts
+++ b/src/model/BucketNode.ts
@@ -22,6 +22,7 @@ import { ScopeSpec } from "couchbase";
 
 export class BucketNode implements INode {
   constructor(
+    public readonly parentNode: INode,
     public readonly connection: IConnection,
     public readonly bucketName: string,
     public readonly isScopesandCollections: boolean,
@@ -63,6 +64,7 @@ export class BucketNode implements INode {
         scopes?.forEach((scope: ScopeSpec) => {
           nodes.push(
             new ScopeNode(
+              this,
               this.connection,
               scope.name,
               this.bucketName,

--- a/src/model/ClusterConnectionNode.ts
+++ b/src/model/ClusterConnectionNode.ts
@@ -55,12 +55,15 @@ export class ClusterConnectionNode implements INode {
     try {
       let buckets = await this.connection.cluster?.buckets().getAllBuckets();
       buckets?.forEach((bucket: BucketSettings) => {
-        nodes.push(new BucketNode(
-          this.connection,
-          bucket.name,
-          isScopesandCollections,
-          vscode.TreeItemCollapsibleState.None
-        ));
+        nodes.push(
+          new BucketNode(
+            this,
+            this.connection,
+            bucket.name,
+            isScopesandCollections,
+            vscode.TreeItemCollapsibleState.None
+          )
+        );
       });
     } catch (err: any) {
       console.log(err);

--- a/src/model/DocumentNode.ts
+++ b/src/model/DocumentNode.ts
@@ -20,6 +20,7 @@ import { INode } from "./INode";
 
 export default class DocumentNode extends vscode.TreeItem {
   constructor(
+    public readonly parentNode: INode,
     public readonly documentName: string,
     public readonly connection: IConnection,
     public readonly scopeName: string,
@@ -44,9 +45,21 @@ export default class DocumentNode extends vscode.TreeItem {
         arguments: [this],
       },
       iconPath: {
-        light: path.join(__filename, "..", "..", "images/light", "documents-icon.svg"),
-        dark: path.join(__filename, "..", "..", "images/dark", "documents-icon.svg"),
-      }
+        light: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/light",
+          "documents-icon.svg"
+        ),
+        dark: path.join(
+          __filename,
+          "..",
+          "..",
+          "images/dark",
+          "documents-icon.svg"
+        ),
+      },
     };
   }
 

--- a/src/model/ScopeNode.ts
+++ b/src/model/ScopeNode.ts
@@ -21,6 +21,7 @@ import CollectionNode from "./CollectionNode";
 
 export class ScopeNode implements INode {
   constructor(
+    public readonly parentNode: INode,
     public readonly connection: IConnection,
     public readonly scopeName: string,
     public readonly bucketName: string,
@@ -63,6 +64,7 @@ export class ScopeNode implements INode {
         const count = queryResult?.rows[0].count;
 
         const collectionTreeItem = new CollectionNode(
+          this,
           this.connection,
           this.scopeName,
           count,


### PR DESCRIPTION
## Describe the problem this PR is solving
It's sometimes useful to have access to the parent node of the currently selected node, for example to refresh a list of available documents after creating a new document.

## Short description of the changes
- Update the tree node implementations to receive their parent node as a constructor arg
- Includes some file formatting automatically applied upon saving

NOTE: This PR just updated the tree nodes to receive their parent, it does not use it yet. Future PRs will use utilise the parent nodes.
