### PR TITLE
DA#95: Modified: Fix refresh collections

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -539,6 +539,7 @@ export function activate(context: vscode.ExtensionContext) {
       "vscode-couchbase.refreshCollections",
       async (node: ScopeNode) => {
         clusterConnectionTreeProvider.refresh(node);
+        clusterConnectionTreeProvider.refresh(node.parentNode);
       }
     )
   );


### PR DESCRIPTION
## Describe the problem this PR is solving
Refresh collections not working

## Short description of the changes
On click on refresh collections the bucket is getting refreshed so that it could refresh whole tree. 
