### PR TITLE
DA#110: Bugfix: Specific status of each connection should be indicated

### DIFF
--- a/src/model/ClusterConnectionNode.ts
+++ b/src/model/ClusterConnectionNode.ts
@@ -32,7 +32,7 @@ export class ClusterConnectionNode implements INode {
 
   public getTreeItem(): vscode.TreeItem {
     const activeConnection = getActiveConnection();
-    this.isActive = this.connection.connectionIdentifier === activeConnection?.connectionIdentifier;
+    this.isActive = this.id === `${activeConnection?.username}@${activeConnection?.url}`;
 
     return {
       label: this.isActive ? `${this.id}` : this.id,


### PR DESCRIPTION
When connecting to multiple clusters, the specific status of each connection (active or inactive) is not indicated. It is possible to view either all active connections or all inactive connections
![](https://user-images.githubusercontent.com/42893909/217209547-864da614-73b5-406b-afca-065a91fc5c7d.png)
After Bugfix:
<img width="603" alt="Screenshot 2023-03-02 at 1 39 17 PM" src="https://user-images.githubusercontent.com/42893909/222369222-f600cfd8-eb0d-4a4f-a18a-83f07ca7a0e4.png">

