### PR TITLE
Da#134 create query notebook for couchbase

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "onCommand:vscode-couchbase.refreshCollections",
     "onCommand:vscode-couchbase.getDocumentMetaData",
     "onCommand:vscode-couchbase.openQueryNotebook",
+    "onNotebook:vscode-couchbase.couchbase-query-notebook",
     "onCustomEditor:vscode-couchbase.couchbaseDocument",
     "onStartupFinished",
     "onView:couchbase-activity-bar"
@@ -310,6 +311,17 @@
         }
       ]
     },
+    "notebooks": [
+      {
+        "type": "couchbase-query-notebook",
+        "displayName": "sql++ query",
+        "selector": [
+          {
+            "filenamePattern": "*.n1ql"
+          }
+        ]
+      }
+    ],
     "commands": [
       {
         "command": "vscode-couchbase.createClusterConnection",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "onCommand:vscode-couchbase.removeCollection",
     "onCommand:vscode-couchbase.refreshCollections",
     "onCommand:vscode-couchbase.getDocumentMetaData",
+    "onCommand:vscode-couchbase.openQueryNotebook",
     "onCustomEditor:vscode-couchbase.couchbaseDocument",
     "onStartupFinished",
     "onView:couchbase-activity-bar"
@@ -317,6 +318,12 @@
         "icon": "images/create.svg"
       },
       {
+        "command": "vscode-couchbase.openQueryNotebook",
+        "title": "New Notebook",
+        "category": "Couchbase",
+        "icon": "images/create.svg"       
+      },
+      {
         "command": "vscode-couchbase.refreshConnection",
         "title": "Refresh Cluster Connection",
         "category": "Couchbase"
@@ -444,6 +451,10 @@
         },
         {
           "command": "vscode-couchbase.disconnectClusterConnection",
+          "when": "view == couchbase && viewItem == active_connection"
+        },
+        {
+          "command": "vscode-couchbase.openQueryNotebook",
           "when": "view == couchbase && viewItem == active_connection"
         },
         {

--- a/package.json
+++ b/package.json
@@ -314,10 +314,10 @@
     "notebooks": [
       {
         "type": "couchbase-query-notebook",
-        "displayName": "sql++ query",
+        "displayName": "SQL++ Query",
         "selector": [
           {
-            "filenamePattern": "*.n1ql"
+            "filenamePattern": "*.n1qlnb"
           }
         ]
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,10 @@ import {
 import { MemFS } from "./util/fileSystemProvider";
 import { Global, Memory, WorkSpace } from "./util/util";
 import { IDocumentData } from "./model/IDocument";
+import { QueryContentSerializer } from "./notebook/serializer";
+import { QueryKernel } from "./notebook/controller";
+import { Constants } from "./util/constants";
+import { createNotebook } from "./notebook/notebook";
 
 export function activate(context: vscode.ExtensionContext) {
   Global.setState(context.globalState);
@@ -707,6 +711,22 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }
     )
+  );
+
+  subscriptions.push(
+    vscode.commands.registerCommand(
+      "vscode-couchbase.openQueryNotebook",
+      async () => {
+        createNotebook();
+      }
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.registerNotebookSerializer(
+      Constants.notebookType, new QueryContentSerializer(), { transientOutputs: true }
+    ),
+    new QueryKernel()
   );
 }
 

--- a/src/notebook/controller.ts
+++ b/src/notebook/controller.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { getActiveConnection } from '../util/connections';
+
+export class QueryKernel {
+    private readonly _id = 'couchbase-query-notebook-kernel';
+    private readonly _label = 'New Couchbase Query Notebook';
+    private readonly _supportedLanguages = ['json', 'sql++'];
+
+    private _executionOrder = 0;
+    private readonly _controller: vscode.NotebookController;
+
+    constructor() {
+        this._controller = vscode.notebooks.createNotebookController(this._id,
+            'couchbase-query-notebook',
+            this._label);
+        this._controller.supportedLanguages = this._supportedLanguages;
+        this._controller.supportsExecutionOrder = true;
+        this._controller.executeHandler = this._executeAll.bind(this);
+    }
+
+    dispose(): void {
+        this._controller.dispose();
+    }
+
+    private _executeAll(cells: vscode.NotebookCell[], _notebook: vscode.NotebookDocument, _controller: vscode.NotebookController): void {
+        for (const cell of cells) {
+            this._doExecution(cell);
+        }
+    }
+
+    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = this._controller.createNotebookCellExecution(cell);
+
+        execution.executionOrder = ++this._executionOrder;
+        execution.start(Date.now());
+
+        try {
+            const activeConnection = getActiveConnection();
+            if (!activeConnection) {
+                return;
+            };
+            const result = await activeConnection.cluster?.query(
+                cell.document.getText()
+            );
+            execution.replaceOutput([new vscode.NotebookCellOutput([
+                vscode.NotebookCellOutputItem.json(result?.rows)
+            ])]);
+
+            execution.end(true, Date.now());
+        } catch (err) {
+            execution.replaceOutput([new vscode.NotebookCellOutput([
+                vscode.NotebookCellOutputItem.error(err as Error)
+            ])]);
+        }
+        execution.end(false, Date.now());
+    }
+}

--- a/src/notebook/controller.ts
+++ b/src/notebook/controller.ts
@@ -1,10 +1,14 @@
 import * as vscode from 'vscode';
 import { getActiveConnection } from '../util/connections';
+import {
+    BucketNotFoundError, CollectionNotFoundError, DocumentNotFoundError,
+    ParsingFailureError, ScopeNotFoundError
+} from 'couchbase';
 
 export class QueryKernel {
     private readonly _id = 'couchbase-query-notebook-kernel';
     private readonly _label = 'New Couchbase Query Notebook';
-    private readonly _supportedLanguages = ['json', 'sql++'];
+    private readonly _supportedLanguages = ['sql++', 'json'];
 
     private _executionOrder = 0;
     private readonly _controller: vscode.NotebookController;
@@ -48,8 +52,27 @@ export class QueryKernel {
 
             execution.end(true, Date.now());
         } catch (err) {
+            const errorArray = [];
+            if (
+                err instanceof ParsingFailureError ||
+                err instanceof BucketNotFoundError ||
+                err instanceof CollectionNotFoundError ||
+                err instanceof DocumentNotFoundError ||
+                err instanceof ScopeNotFoundError
+            ) {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                const { first_error_code, first_error_message, statement } = err.cause as any;
+                errorArray.push({
+                    code: first_error_code,
+                    msg: first_error_message,
+                    query: statement,
+                });
+            }
+            else {
+                errorArray.push(err);
+            }
             execution.replaceOutput([new vscode.NotebookCellOutput([
-                vscode.NotebookCellOutputItem.error(err as Error)
+                vscode.NotebookCellOutputItem.json(errorArray)
             ])]);
         }
         execution.end(false, Date.now());

--- a/src/notebook/controller.ts
+++ b/src/notebook/controller.ts
@@ -5,7 +5,15 @@ import {
     ParsingFailureError, ScopeNotFoundError
 } from 'couchbase';
 
+/**
+ * // This is a typescript class for creating and handling the execution of a new Couchbase Query Notebook,
+ * which has an executeAll method that executes all cells in a query notebook when called. 
+ * It also has a doExecution method which handles the individual execution of each cell, 
+ * including managing the creation of the notebook cell execution and replacing the output 
+ * with the result or error messages depending on the execution's state.
+ */
 export class QueryKernel {
+    // Private properties to set an ID, label and the types of languages it supports
     private readonly _id = 'couchbase-query-notebook-kernel';
     private readonly _label = 'New Couchbase Query Notebook';
     private readonly _supportedLanguages = ['sql++', 'json'];
@@ -13,28 +21,31 @@ export class QueryKernel {
     private _executionOrder = 0;
     private readonly _controller: vscode.NotebookController;
 
+    // Constructor used to create new QueryKernel objects
     constructor() {
-        this._controller = vscode.notebooks.createNotebookController(this._id,
+        this._controller = vscode.notebooks.createNotebookController(
+            this._id,
             'couchbase-query-notebook',
-            this._label);
+            this._label
+        );
         this._controller.supportedLanguages = this._supportedLanguages;
         this._controller.supportsExecutionOrder = true;
         this._controller.executeHandler = this._executeAll.bind(this);
     }
 
-    dispose(): void {
-        this._controller.dispose();
-    }
+    // Method to release any resources being held, currently it just disposes the notebook controller
+    dispose(): void { this._controller.dispose(); }
 
+    // This is the main method to execute all cells' queries. It will be called by the internal VBox office code when a user requests to execute all the content of this kernel.
     private _executeAll(cells: vscode.NotebookCell[], _notebook: vscode.NotebookDocument, _controller: vscode.NotebookController): void {
         for (const cell of cells) {
             this._doExecution(cell);
         }
     }
 
+    //The core function that executes query from each individual notebook cell
     private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
         const execution = this._controller.createNotebookCellExecution(cell);
-
         execution.executionOrder = ++this._executionOrder;
         execution.start(Date.now());
 

--- a/src/notebook/notebook.ts
+++ b/src/notebook/notebook.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+import { Constants } from '../util/constants';
+
+export const createNotebook = async () => {
+    const language = 'sql++';
+    const defaultValue = ``;
+    const cell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, defaultValue, language);
+    const data = new vscode.NotebookData([cell]);
+    data.metadata = {
+        custom: {
+            cells: [],
+            metadata: {
+                orig_nbformat: 4
+            },
+            nbformat: 4,
+            nbformat_minor: 2
+        }
+    };
+    const doc = await vscode.workspace.openNotebookDocument(Constants.notebookType, data);
+    await vscode.window.showNotebookDocument(doc);
+};

--- a/src/notebook/notebook.ts
+++ b/src/notebook/notebook.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 import { Constants } from '../util/constants';
 
+/**
+ * This code exports a createNotebook function that creates a new notebook in VS Code's UI with an empty SQL++ cell. 
+ */
 export const createNotebook = async () => {
     const language = 'sql++';
     const defaultValue = ``;
@@ -10,9 +13,11 @@ export const createNotebook = async () => {
         custom: {
             cells: [],
             metadata: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 orig_nbformat: 4
             },
             nbformat: 4,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             nbformat_minor: 2
         }
     };

--- a/src/notebook/serializer.ts
+++ b/src/notebook/serializer.ts
@@ -12,6 +12,12 @@ interface RawNotebookCell {
     editable?: boolean;
 }
 
+/**
+ * Serializes and Deserializes the content of a notebook. 
+ * It reads raw/unprocessed file contents, parse it to JavaScript Object Notation (JSON) format,
+ *  creates an array of Notebook cells, maps data into the desired format and then converts
+ *  it back to a binary format using text encoding/decoding algorithms.
+ */
 export class QueryContentSerializer implements vscode.NotebookSerializer {
     public readonly label: string = 'New Query Notebook Serializer';
 

--- a/src/notebook/serializer.ts
+++ b/src/notebook/serializer.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+import { TextDecoder, TextEncoder } from 'util';
+
+interface RawNotebookData {
+    cells: RawNotebookCell[]
+}
+
+interface RawNotebookCell {
+    language: string;
+    value: string;
+    kind: vscode.NotebookCellKind;
+    editable?: boolean;
+}
+
+export class QueryContentSerializer implements vscode.NotebookSerializer {
+    public readonly label: string = 'New Query Notebook Serializer';
+
+    public async deserializeNotebook(data: Uint8Array, token: vscode.CancellationToken): Promise<vscode.NotebookData> {
+        const contents = new TextDecoder().decode(data); // convert to String
+
+        // Read file contents
+        let raw: RawNotebookData;
+        try {
+            raw = <RawNotebookData>JSON.parse(contents);
+        } catch {
+            raw = { cells: [] };
+        }
+
+        // Create array of Notebook cells for the VS Code API from file contents
+        const cells = raw.cells.map(item => new vscode.NotebookCellData(
+            item.kind,
+            item.value,
+            item.language
+        ));
+
+        return new vscode.NotebookData(cells);
+    }
+
+    public async serializeNotebook(data: vscode.NotebookData, token: vscode.CancellationToken): Promise<Uint8Array> {
+        // Map the Notebook data into the format we want to save the Notebook data as
+        const contents: RawNotebookData = { cells: [] };
+
+        for (const cell of data.cells) {
+            contents.cells.push({
+                kind: cell.kind,
+                language: cell.languageId,
+                value: cell.value
+            });
+        }
+
+        return new TextEncoder().encode(JSON.stringify(contents));
+    }
+}

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -16,4 +16,5 @@
 export class Constants {
   public static extensionID = "vscode-couchbase";
   public static connectionKeys = "cluster.connections";
+  public static notebookType = "couchbase-query-notebook";
 }


### PR DESCRIPTION
## Describe the problem this PR is solving
Creating a query notebook functionality similar to Jupyter Notebook. It would allow users to write and run multiple queries in a single document with interactive cells containing commands that can be executed independently of one another. This feature would provide a more user-friendly way to work with queries, and greatly improve productivity when working with Couchbase databases.

A query notebook would also have various benefits such as:

Composing and documenting complex queries easily.
Saving and loading queries from past sessions or documents.
Giving users the option to directly copy an
<img width="1728" alt="Screenshot 2023-03-14 at 3 52 14 PM" src="https://user-images.githubusercontent.com/42893909/224971178-4ea89920-64ac-4b81-94fb-99f3c72ac2d2.png">
<img width="1728" alt="Screenshot 2023-03-14 at 3 52 24 PM" src="https://user-images.githubusercontent.com/42893909/224971214-c2fc2c32-2d3a-4a43-8120-2c95cdb75224.png">
d paste queries to other files.


