### PR TITLE
In the absence of any database connectivity, a Query Notebook ought to generate an error message when a query is executed

### DIFF
--- a/src/notebook/controller.ts
+++ b/src/notebook/controller.ts
@@ -52,7 +52,8 @@ export class QueryKernel {
         try {
             const activeConnection = getActiveConnection();
             if (!activeConnection) {
-                return;
+                vscode.window.showErrorMessage("Connection Failure: Looks like you are not connected to cluster \nPlease check your cluster connection and try again", { modal: true });
+                throw Error('Connection Failed');
             };
             const result = await activeConnection.cluster?.query(
                 cell.document.getText()


### PR DESCRIPTION
## Describe the problem this PR is solving
When we attempt to execute a query on a notebook with an inactive connection, the system will make an effort to retrieve and display the output and stay in that state only, instead of generating an error message.

## Short description of the changes
Throw an error if connection is not established. 