### PR TITLE
Conflict when we create a new document and provide an Id that already exists should be removed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -359,6 +359,9 @@ export function activate(context: vscode.ExtensionContext) {
             .scope(node.scopeName)
             .collection(node.collectionName)
             .get(documentName);
+          if (result) {
+            uriToCasMap.set(uri.toString(), result.cas.toString());
+          }
           documentContent = Buffer.from(
             JSON.stringify(result?.content, null, 2)
           );


### PR DESCRIPTION
When we create a new document and provide an Id that already exists (hotel_10025) , It is giving conflict with the document that is in server is now solved and the current behaviour is simply opening the already existing document.