### PR TITLE
fixed for Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For Red Hat, CentOS or Fedora-based distros:
 For Mac:
 - Run `brew install openssl` using Homebrew, or download the latest version of OpenSSL from https://www.openssl.org/source/ and follow the installation instructions.
 
+> :warning:  **WARNING**:  DO NOT upgrade cmake-js to 7.x or it will break Windows builds. Please use 6.x instead. 
+
 ## Contributions & Community
 
 *This is not an officially supported Couchbase project, however we welcome contributions from the community via GitHub features such as the Issues tab.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "axios": "^0.21.4",
         "couchbase": "^4.2.1",
-        "keytar": "^7.7.0"
+        "keytar": "^7.7.0",
+        "node-addon-api": "^6.0.0"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -21,7 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "@vscode/test-electron": "^2.1.5",
-        "cmake-js": "^7.1.1",
+        "cmake-js": "^6.3.2",
         "electron-rebuild": "^3.2.7",
         "eslint": "^7.32.0",
         "glob": "^7.2.0",
@@ -865,7 +866,8 @@
     },
     "node_modules/ansi": {
       "version": "0.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A=="
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -949,11 +951,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "0.21.4",
@@ -1140,7 +1137,8 @@
     },
     "node_modules/buffer-shims": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g=="
     },
     "node_modules/buffers": {
       "version": "0.1.1",
@@ -1260,7 +1258,8 @@
     },
     "node_modules/camelcase": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1456,43 +1455,343 @@
       }
     },
     "node_modules/cmake-js": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.2.tgz",
+      "integrity": "sha512-7MfiQ/ijzeE2kO+WFB9bv4QP5Dn2yVaAP2acFJr4NIFy2hT4w6O4EpOTLNcohR5IPX7M4wNf/5taIqMj7UA9ug==",
       "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^0.21.1",
+        "bluebird": "^3",
         "debug": "^4",
-        "fs-extra": "^10.1.0",
-        "lodash.isplainobject": "^4.0.6",
-        "memory-stream": "^1.0.0",
-        "node-api-headers": "^0.0.1",
-        "npmlog": "^6.0.2",
+        "fs-extra": "^5.0.0",
+        "is-iojs": "^1.0.1",
+        "lodash": "^4",
+        "memory-stream": "0",
+        "npmlog": "^1.2.0",
         "rc": "^1.2.7",
-        "semver": "^7.3.8",
-        "tar": "^6.1.11",
-        "url-join": "^4.0.1",
-        "which": "^2.0.2",
-        "yargs": "^17.6.0"
+        "semver": "^5.0.3",
+        "splitargs": "0",
+        "tar": "^4",
+        "unzipper": "^0.8.13",
+        "url-join": "0",
+        "which": "^1.0.9",
+        "yargs": "^3.6.0"
       },
       "bin": {
         "cmake-js": "bin/cmake-js"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/cmake-js/node_modules/axios": {
-      "version": "0.27.2",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/cmake-js/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/are-we-there-yet": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha512-Zfw6bteqM9gQXZ1BIWOgM8xEwMrUGoyL8nW13+O+OOgNX3YhuDN1GDgg1NzdTlmm3j+9sHy7uBZ12r+z9lXnZQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
+      }
+    },
+    "node_modules/cmake-js/node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+    },
+    "node_modules/cmake-js/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/cmake-js/node_modules/cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
+      "dependencies": {
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/cmake-js/node_modules/minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/cmake-js/node_modules/npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha512-1J5KqSRvESP6XbjPaXt2H6qDzgizLTM7x0y1cXIjP2PpvdCqyNC7TO3cPRKsuYlElbi/DwkzRRdG2zpmE0IktQ==",
+      "dependencies": {
+        "ansi": "~0.3.0",
+        "are-we-there-yet": "~1.0.0",
+        "gauge": "~1.2.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cmake-js/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/cmake-js/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/cmake-js/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/cmake-js/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/tar": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/cmake-js/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/unzipper": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "~1.0.10",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.1.5",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/cmake-js/node_modules/unzipper/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw=="
+    },
+    "node_modules/cmake-js/node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "integrity": "sha512-NkXT2AER7VKXeXtJNSaWLpWIhmtSE3K2PguaLEeWr4JILghcIKqoLt1A3wHrnpDC5+ekf8gfk1GKWkFXe4odMw==",
+      "dependencies": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cmake-js/node_modules/unzipper/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/cmake-js/node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw=="
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/cmake-js/node_modules/wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/y18n": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+    },
+    "node_modules/cmake-js/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "node_modules/cmake-js/node_modules/yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
+      "dependencies": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
       }
     },
     "node_modules/code-point-at": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1525,17 +1824,6 @@
       "version": "2.0.19",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "6.2.1",
@@ -1572,322 +1860,10 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/couchbase/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/are-we-there-yet": {
-      "version": "1.0.6",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.0 || ^1.1.13"
-      }
-    },
-    "node_modules/couchbase/node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/couchbase/node_modules/are-we-there-yet/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/bluebird": {
-      "version": "3.4.7",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC"
-    },
-    "node_modules/couchbase/node_modules/cliui": {
-      "version": "3.2.0",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/cmake-js": {
-      "version": "6.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "bluebird": "^3",
-        "debug": "^4",
-        "fs-extra": "^5.0.0",
-        "is-iojs": "^1.0.1",
-        "lodash": "^4",
-        "memory-stream": "0",
-        "npmlog": "^1.2.0",
-        "rc": "^1.2.7",
-        "semver": "^5.0.3",
-        "splitargs": "0",
-        "tar": "^4",
-        "unzipper": "^0.8.13",
-        "url-join": "0",
-        "which": "^1.0.9",
-        "yargs": "^3.6.0"
-      },
-      "bin": {
-        "cmake-js": "bin/cmake-js"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/fs-extra": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/fs-minipass": {
-      "version": "1.2.7",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^2.6.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/gauge": {
-      "version": "1.2.7",
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "^0.3.0",
-        "has-unicode": "^2.0.0",
-        "lodash.pad": "^4.1.0",
-        "lodash.padend": "^4.1.0",
-        "lodash.padstart": "^4.1.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/couchbase/node_modules/memory-stream": {
-      "version": "0.0.3",
-      "license": "MMIT",
-      "dependencies": {
-        "readable-stream": "~1.0.26-2"
-      }
-    },
-    "node_modules/couchbase/node_modules/minipass": {
-      "version": "2.9.0",
-      "license": "ISC",
-      "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/minizlib": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^2.9.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/couchbase/node_modules/npmlog": {
-      "version": "1.2.1",
-      "license": "ISC",
-      "dependencies": {
-        "ansi": "~0.3.0",
-        "are-we-there-yet": "~1.0.0",
-        "gauge": "~1.2.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/couchbase/node_modules/readable-stream/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/couchbase/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/string-width": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/tar": {
-      "version": "4.4.19",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^1.1.4",
-        "fs-minipass": "^1.2.7",
-        "minipass": "^2.9.0",
-        "minizlib": "^1.3.3",
-        "mkdirp": "^0.5.5",
-        "safe-buffer": "^5.2.1",
-        "yallist": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=4.5"
-      }
-    },
-    "node_modules/couchbase/node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/unzipper": {
-      "version": "0.8.14",
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "~1.0.10",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.1.5",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/couchbase/node_modules/unzipper/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/couchbase/node_modules/url-join": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/couchbase/node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/couchbase/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/couchbase/node_modules/y18n": {
-      "version": "3.2.2",
-      "license": "ISC"
-    },
-    "node_modules/couchbase/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
-    "node_modules/couchbase/node_modules/yargs": {
-      "version": "3.32.0",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      }
+    "node_modules/couchbase/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1945,7 +1921,8 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2002,14 +1979,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2660,19 +2629,6 @@
         }
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "license": "MIT"
@@ -3170,7 +3126,8 @@
     },
     "node_modules/invert-kv": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3417,7 +3374,8 @@
     },
     "node_modules/lcid": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -3496,11 +3454,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -3508,15 +3461,18 @@
     },
     "node_modules/lodash.pad": {
       "version": "4.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg=="
     },
     "node_modules/lodash.padend": {
       "version": "4.6.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw=="
     },
     "node_modules/lodash.padstart": {
       "version": "4.6.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -3696,12 +3652,33 @@
       }
     },
     "node_modules/memory-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+      "integrity": "sha512-q0D3m846qY6ZkIt+19ZemU5vH56lpOZZwoJc3AICARKh/menBuayQUjAGPrqtHQQMUYERSdOrej92J9kz7LgYA==",
       "dependencies": {
-        "readable-stream": "^3.4.0"
+        "readable-stream": "~1.0.26-2"
       }
+    },
+    "node_modules/memory-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/memory-stream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/memory-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4116,13 +4093,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "license": "MIT"
-    },
-    "node_modules/node-api-headers": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
+      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
     },
     "node_modules/node-api-version": {
       "version": "0.1.4",
@@ -4248,7 +4221,8 @@
     },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4322,7 +4296,8 @@
     },
     "node_modules/os-locale": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -5997,7 +5972,8 @@
     },
     "node_modules/window-size": {
       "version": "0.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw==",
       "bin": {
         "window-size": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "@vscode/test-electron": "^2.1.5",
-    "cmake-js": "^7.1.1",
+    "cmake-js": "^6.3.2",
     "electron-rebuild": "^3.2.7",
     "eslint": "^7.32.0",
     "glob": "^7.2.0",
@@ -57,7 +57,8 @@
   "dependencies": {
     "axios": "^0.21.4",
     "couchbase": "^4.2.1",
-    "keytar": "^7.7.0"
+    "keytar": "^7.7.0",
+    "node-addon-api": "^6.0.0"
   },
   "activationEvents": [
     "onFileSystem:couchbase",


### PR DESCRIPTION
## Describe the problem this PR is solving
This PR will fix builds with Windows 10 and 11

## Short description of the changes
This PR changes the version of cmake-js to version 6.3.2.  This version also adds in the library node-addon-api because without it you will get errors when building the Couchbase Node SDK on older versions of cmake-js than 7.x.

The readme was updating warning people to not upgrade to version 7.x of cmake-js because that will break windows builds.
