### PR TITLE
Connection string should not contain scheme, but "use secure" checkbox

### DIFF
--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -92,8 +92,14 @@ export async function addConnection(clusterConnectionTreeProvider: ClusterConnec
   currentPanel.webview.onDidReceiveMessage(async (message: any) => {
     switch (message.command) {
       case 'submit':
+        let url;
         try {
-          await Cluster.connect(message.url, { username: message.username, password: message.password, configProfile: 'wanDevelopment' });
+          if (message.isSecure) {
+            url = Constants.prefixSecureURL + message.url;
+          } else {
+            url = Constants.prefixURL + message.url;
+          }
+          await Cluster.connect(url, { username: message.username, password: message.password, configProfile: 'wanDevelopment' });
         } catch (err) {
           handleConnectionError(err);
           currentPanel.dispose();
@@ -101,7 +107,7 @@ export async function addConnection(clusterConnectionTreeProvider: ClusterConnec
           break;
         }
 
-        const connection: IConnection = { url: message.url, username: message.username, password: message.password, connectionIdentifier: message.connectionIdentifier };
+        const connection: IConnection = { url, username: message.username, password: message.password, connectionIdentifier: message.connectionIdentifier };
         const connections = getConnections();
         const connectionId = getConnectionId(connection);
         if (connections && connections[connectionId]) {

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -17,4 +17,6 @@ export class Constants {
   public static extensionID = "vscode-couchbase";
   public static connectionKeys = "cluster.connections";
   public static notebookType = "couchbase-query-notebook";
+  public static prefixSecureURL = "couchbases://";
+  public static prefixURL = "couchbase://";
 }

--- a/src/webViews/connectionScreen.webview.ts
+++ b/src/webViews/connectionScreen.webview.ts
@@ -50,6 +50,30 @@ export function getClusterConnectingFormView(message: any): string {
                 color: var(--vscode-button-foreground);
                 background: var(--vscode-button-background);
                 }
+                input[type="checkbox"] {
+                    appearance: none;
+                    -webkit-appearance: none;
+                    width: 15px;
+                    height: 15px;
+                    border-radius: 2px;
+                    outline: none;
+                    border: 1px solid #999;
+                    background-color: white;
+                }
+                
+                input[type="checkbox"]:checked {
+                    background-color: #ea2328;
+                }
+        
+                input[type="checkbox"]:checked::before {
+                    content: '\\2714';
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    font-size: 12px;
+                    color: white;
+                    height: 100%;
+                }
                 .redButton{
                 background: #ea2328;
                 }
@@ -95,7 +119,7 @@ export function getClusterConnectingFormView(message: any): string {
                 margin: 50px;
                 }
                 .left-container {
-                width: 50%;
+                width: 60%;
                 }
                 .right-container {
                 background: #f2f2f2;
@@ -117,6 +141,10 @@ export function getClusterConnectingFormView(message: any): string {
                 flex-wrap: wrap;
                 gap: 12px;
                 }
+                .secure-box {
+                    display: flex;
+                    align-items: center;
+                }
             </style>
         </head>
         <body>
@@ -126,8 +154,14 @@ export function getClusterConnectingFormView(message: any): string {
                     <b>Enter your connection details below</b><br><br>
                     <div>
                     <label for="url">Cluster Connection URL</label><br>
-                    <input type="text" id="url" name="url" placeholder="couchbase://localhost" value=${message?.url ?? "couchbase://localhost"} />
-                    <span id="urlErr" class="error-message"></span><br/><br/>
+                    <input type="text" id="url" name="url" placeholder="localhost" value=${message?.url ?? "localhost"} />
+                    <div class="secure-box">
+                    <label for="secure">Secure</label> 
+                    <input type="checkbox" id="secureCheck">
+                    </div>
+                    <span id="urlErr" class="error-message"></span><br/>
+                    
+                    <br/>
                     <label for="url">Username</label><br>
                     <input type="text" id="username" name="username" placeholder="Username" value=${message?.username ?? "Administrator"} />
                     <span id="usernameErr" class="error-message"></span><br/><br/>
@@ -236,12 +270,14 @@ export function getClusterConnectingFormView(message: any): string {
                     let username = document.getElementById('username').value;
                     let password = document.getElementById('password').value;
                     let identifier = document.getElementById('connectionIdentifier').value;
+                    var checkBox = document.getElementById("secureCheck");
                     vscode.postMessage({
                         command: 'submit',
                         url: url,
                         username: username,
                         password: password,
                         connectionIdentifier: identifier
+                        isSecure: checkBox.checked
                     })
                 };
                 function cancelRequest(){

--- a/src/webViews/connectionScreen.webview.ts
+++ b/src/webViews/connectionScreen.webview.ts
@@ -182,12 +182,12 @@ export function getClusterConnectingFormView(message: any): string {
                     <div>
                         <h2>
                         New to Couchbase and don't have a cluster?
-                        <h2>
+                        </h2>
                     </div>
                     <div>
                         <h4>
                         If you don't already have a cluster you can install couchbase locally or create a cluster using capella
-                        <h4>
+                        </h4>
                     </div>
                     <a href="https://www.couchbase.com/downloads/?family=couchbase-server">
                     <button class="redButton" type="button">Download</button>
@@ -270,13 +270,17 @@ export function getClusterConnectingFormView(message: any): string {
                     let username = document.getElementById('username').value;
                     let password = document.getElementById('password').value;
                     let identifier = document.getElementById('connectionIdentifier').value;
-                    var checkBox = document.getElementById("secureCheck");
+                    let checkBox = document.getElementById("secureCheck");
+                    if(url.startsWith("couchbase://") || url.startsWith("couchbases://"))
+                    {
+                        url = url.slice(url.indexOf('//') + 2);
+                    }
                     vscode.postMessage({
                         command: 'submit',
                         url: url,
                         username: username,
                         password: password,
-                        connectionIdentifier: identifier
+                        connectionIdentifier: identifier,
                         isSecure: checkBox.checked
                     })
                 };

--- a/src/webViews/connectionScreen.webview.ts
+++ b/src/webViews/connectionScreen.webview.ts
@@ -142,6 +142,8 @@ export function getClusterConnectingFormView(message: any): string {
                 gap: 12px;
                 }
                 .secure-box {
+                    margin-top: 5px;
+                    gap: 2px;
                     display: flex;
                     align-items: center;
                 }
@@ -156,11 +158,10 @@ export function getClusterConnectingFormView(message: any): string {
                     <label for="url">Cluster Connection URL</label><br>
                     <input type="text" id="url" name="url" placeholder="localhost" value=${message?.url ?? "localhost"} />
                     <div class="secure-box">
-                    <label for="secure">Secure</label> 
                     <input type="checkbox" id="secureCheck">
+                    <label for="secure">Secure</label> 
                     </div>
                     <span id="urlErr" class="error-message"></span><br/>
-                    
                     <br/>
                     <label for="url">Username</label><br>
                     <input type="text" id="username" name="username" placeholder="Username" value=${message?.username ?? "Administrator"} />


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
Currently, when you are connecting to a server you need to have the scheme, which basically only define if the connection is secured or not.

Describe the solution you'd like
Scheme is not needed here, to make it more streamlined, all we need is the connection string and a checkbox, whether to use secure or not.

Also handle the case If the user enters a connection string with couchbase:// or couchbases:// by removing them. 
<img width="1380" alt="Screenshot 2023-04-10 at 4 14 39 PM" src="https://user-images.githubusercontent.com/42893909/230887177-5808ad62-73e8-4daa-b31e-4110a4cfca5d.png">

