### PR TITLE
The default scope can not have delete option

### DIFF
--- a/src/model/ScopeNode.ts
+++ b/src/model/ScopeNode.ts
@@ -34,7 +34,7 @@ export class ScopeNode implements INode {
     return {
       label: `${this.scopeName}`,
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-      contextValue: "scope",
+      contextValue: this.scopeName === "_default" ? "default_scope" : "scope",
       iconPath: {
         light: path.join(
           __filename,


### PR DESCRIPTION
The default scope cannot be dropped. The default collection can be dropped, by means of either the Couchbase CLI, or the REST API. So we should avoid user seeing _default scope