### PR TITLE
Remove checking connection before saving and the connection should not be saved if it fails

### DIFF
--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -97,7 +97,7 @@ export async function addConnection(clusterConnectionTreeProvider: ClusterConnec
         const connections = getConnections();
         const connectionId = getConnectionId(connection);
         if (connections && connections[connectionId]) {
-          const answer = await vscode.window.showInformationMessage(`A connection name '${connections[connectionId].connectionIdentifier}' already exist with the same user & server.\n To proceed, either delete the existing connection & try again or continue to the existing connection.`, { modal: true }, "Connect to Existing");
+          const answer = await vscode.window.showInformationMessage(`A connection named '${connections[connectionId].connectionIdentifier}' already contains the same user and server.\n To proceed, either delete the existing connection & try again or continue to the existing connection`, { modal: true }, "Connect to Existing");
           // If the user chooses the "Connect to Existing" option, use the existing connection, refresh the UI and close the current panel.
           if (answer === "Connect to Existing") {
             await useConnection(connections[connectionId]);

--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -93,22 +93,6 @@ export async function addConnection(clusterConnectionTreeProvider: ClusterConnec
     switch (message.command) {
       case 'submit':
         const url = message.isSecure ? (Constants.prefixSecureURL + message.url) : (Constants.prefixURL + message.url);
-        try {
-          await vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: 'Checking connection...',
-            cancellable: true
-          }, async () => {
-            await Cluster.connect(url, { username: message.username, password: message.password, configProfile: 'wanDevelopment' });
-          });
-
-        } catch (err) {
-          handleConnectionError(err);
-          currentPanel.dispose();
-          addConnection(clusterConnectionTreeProvider, message);
-          break;
-        }
-
         const connection: IConnection = { url, username: message.username, password: message.password, connectionIdentifier: message.connectionIdentifier };
         const connections = getConnections();
         const connectionId = getConnectionId(connection);


### PR DESCRIPTION
- If user try to connect to existing connection, it will ask user to delete the connection first as it already exist or connect to existing connection
- User will get two choices "Continue to Existing" and "Cancel"
- User needs to delete the cluster by itself