### PR TITLE
Refresh the connection automatically when FileNotFound scenario occur

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ import DocumentNode from "./model/DocumentNode";
 import { DocumentNotFoundError } from "couchbase";
 import { IConnection } from "./model/IConnection";
 import { INode } from "./model/INode";
-import { logger } from "./Logging/logger";
+import { logger } from "./logging/logger";
 import { PagerNode } from "./model/PagerNode";
 import { ScopeNode } from "./model/ScopeNode";
 import { getBucketMetaData, getDocumentMetaData } from "./webViews/metaData.webview";
@@ -348,9 +348,11 @@ export function activate(context: vscode.ExtensionContext) {
           await vscode.window.showTextDocument(document, { preview: false });
           return true;
         } catch (err: any) {
+          if (err instanceof vscode.FileSystemError && err.name === 'EntryNotFound (FileSystemError)') {
+            clusterConnectionTreeProvider.refresh();
+          }
           logger.error("Failed to open Document");
           logger.debug(err);
-          clusterConnectionTreeProvider.refresh();
         }
       }
     )
@@ -679,7 +681,7 @@ export function activate(context: vscode.ExtensionContext) {
               context.subscriptions
             );
           }
-        } catch(err) {
+        } catch (err) {
           logger.error(
             `Bucket metadata retrieval failed for \`${node.bucketName}\``
           );
@@ -725,7 +727,7 @@ export function activate(context: vscode.ExtensionContext) {
               context.subscriptions
             );
           }
-        } catch(err) {
+        } catch (err) {
           logger.error(
             `Document metadata retrieval failed for '${node.documentName}'`
           );

--- a/src/model/BucketNode.ts
+++ b/src/model/BucketNode.ts
@@ -20,7 +20,7 @@ import { INode } from "./INode";
 import { ScopeNode } from "./ScopeNode";
 import { ScopeSpec } from "couchbase";
 import InformationNode from "./InformationNode";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export class BucketNode implements INode {
   constructor(

--- a/src/model/ClusterConnectionNode.ts
+++ b/src/model/ClusterConnectionNode.ts
@@ -22,7 +22,7 @@ import { BucketNode } from "./BucketNode";
 import { BucketSettings } from "couchbase";
 import { getActiveConnection } from "../util/connections";
 import InformationNode from "./InformationNode";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export class ClusterConnectionNode implements INode {
   constructor(
@@ -41,8 +41,8 @@ export class ClusterConnectionNode implements INode {
       collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
       contextValue: this.isActive ? "active_connection" : "connection",
       iconPath: {
-        light: path.join(__filename, "..", "..", "images", this.isActive ? "": "light", "cb-logo-icon.svg"),
-        dark: path.join(__filename, "..", "..", "images", this.isActive ? "": "dark", "cb-logo-icon.svg"),
+        light: path.join(__filename, "..", "..", "images", this.isActive ? "" : "light", "cb-logo-icon.svg"),
+        dark: path.join(__filename, "..", "..", "images", this.isActive ? "" : "dark", "cb-logo-icon.svg"),
       }
     };
   }
@@ -72,8 +72,7 @@ export class ClusterConnectionNode implements INode {
       logger.debug(err);
       throw new Error(err);
     }
-    if(nodes.length === 0)
-    {
+    if (nodes.length === 0) {
       nodes.push(new InformationNode("No buckets found"));
     }
     return nodes;

--- a/src/model/CollectionDirectory.ts
+++ b/src/model/CollectionDirectory.ts
@@ -19,7 +19,7 @@ import { IConnection } from "./IConnection";
 import { INode } from "./INode";
 import CollectionNode from "./CollectionNode";
 import InformationNode from "./InformationNode";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export class CollectionDirectory implements INode {
     constructor(

--- a/src/model/CollectionNode.ts
+++ b/src/model/CollectionNode.ts
@@ -22,7 +22,7 @@ import { PagerNode } from "./PagerNode";
 import { abbreviateCount } from "../util/common";
 import { PlanningFailureError } from "couchbase";
 import InformationNode from "./InformationNode";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export default class CollectionNode implements INode {
   constructor(

--- a/src/model/IndexDirectory.ts
+++ b/src/model/IndexDirectory.ts
@@ -23,7 +23,7 @@ import axios from "axios";
 import { Constants } from "../util/constants";
 import { getConnectionId } from "../util/connections";
 import InformationNode from "./InformationNode";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export class IndexDirectory implements INode {
     constructor(

--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -22,7 +22,7 @@ import { IConnection } from "../model/IConnection";
 import { AuthenticationFailureError, Cluster } from "couchbase";
 import { getClusterConnectingFormView } from "../webViews/connectionScreen.webview";
 import ClusterConnectionTreeProvider from "../tree/ClusterConnectionTreeProvider";
-import { logger } from "../Logging/logger";
+import { logger } from "../logging/logger";
 
 export function getConnectionId(connection: IConnection) {
   const { url, username } = connection;


### PR DESCRIPTION
To avoid the need for manual cluster connection refresh and ensure that documents load properly, the connection will be automatically refreshed in the event of a FileNotFound scenario. 
Initially, the user won't be able to open the document, but the user will be able to open the document next time by clicking on it.