### PR TITLE
Show no index available when no indexes are available to list the document for a collection

### DIFF
--- a/src/model/CollectionNode.ts
+++ b/src/model/CollectionNode.ts
@@ -95,6 +95,10 @@ export default class CollectionNode implements INode {
             `SELECT RAW META().id FROM \`${this.bucketName}\`.\`${this.scopeName}\`.\`${this.collectionName}\` LIMIT ${this.limit}`
           );
         }
+        else {
+          const infoNode: InformationNode = new InformationNode("No indexes available", "No indexes available to list the documents in this collection");
+          documentList.push(infoNode);
+        }
       }
     }
     result?.rows.forEach((documentName: string) => {
@@ -113,7 +117,7 @@ export default class CollectionNode implements INode {
     // TODO: add local only (un-synchronized) files to documentList
     if (documentList.length === 0) {
       documentList.push(new InformationNode("No Documents found"));
-    } else if (this.documentCount !== documentList.length) {
+    } else if (this.documentCount > documentList.length) {
       documentList.push(new PagerNode(this));
     }
     return documentList;

--- a/src/model/InformationNode.ts
+++ b/src/model/InformationNode.ts
@@ -18,13 +18,14 @@ import * as path from "path";
 import { INode } from "./INode";
 
 export default class InformationNode implements INode {
-    constructor(public readonly message: string) { }
+    constructor(public readonly message: string, public readonly tooltip?: string) { }
 
     public async getTreeItem(): Promise<vscode.TreeItem> {
         return {
             label: `${this.message}`,
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             contextValue: "info-icon",
+            tooltip: `${this.tooltip ?? ""}`,
             iconPath: {
                 light: path.join(
                     __filename,


### PR DESCRIPTION
The information message will only say "No index available" but we hover over that node we can see the full warning saying
"No indexes available to list the documents in this collection"

<img width="799" alt="Screenshot 2023-05-09 at 12 21 16 PM" src="https://user-images.githubusercontent.com/42893909/237017143-90ee35cd-112d-4c94-a79e-981d92efa52a.png">


