### PR TITLE
Bugfix delete document failure when hover and delete and update URI when search a document

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -468,11 +468,16 @@ export function activate(context: vscode.ExtensionContext) {
           .scope(node.scopeName)
           .collection(node.collectionName)
           .remove(node.documentName);
-
-        const uri = vscode.Uri.parse(
-          `couchbase:/${node.bucketName}/${node.scopeName}/Collections/${node.collectionName}/${node.documentName}.json`
-        );
-        memFs.delete(uri);
+        try {
+          const uri = vscode.Uri.parse(
+            `couchbase:/${node.bucketName}/${node.scopeName}/Collections/${node.collectionName}/${node.documentName}.json`
+          );
+          memFs.delete(uri);
+        } catch (err) {
+          if (!(err instanceof vscode.FileSystemError)) {
+            logger.error(err);
+          }
+        }
         logger.info(`${node.bucketName}: ${node.scopeName}: ${node.collectionName}: The document named ${node.documentName} has been deleted`);
         clusterConnectionTreeProvider.refresh();
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -771,6 +771,9 @@ export function activate(context: vscode.ExtensionContext) {
           const uri = vscode.Uri.parse(
             `couchbase:/${node.bucketName}/${node.scopeName}/Collections/${node.collectionName}/${documentName}.json`
           );
+          if (result) {
+            uriToCasMap.set(uri.toString(), result.cas.toString());
+          }
           memFs.writeFile(
             uri,
             Buffer.from(JSON.stringify(result?.content, null, 2)),


### PR DESCRIPTION
Fixing two bugs:
1. When we hover over a document and delete it, it was not updating in the tree immediately.
2. When we search a document, the URI_to_CAS_map should get updated