### PR TITLE
Add sample project workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.21.4",
         "couchbase": "^4.2.1",
+        "gitly": "^2.4.2",
         "keytar": "^7.7.0",
         "node-addon-api": "^6.0.0"
       },
@@ -952,6 +953,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
@@ -1365,7 +1371,6 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -1825,6 +1830,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "6.2.1",
       "dev": true,
@@ -1979,6 +1995,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2629,6 +2653,19 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "license": "MIT"
@@ -2648,7 +2685,6 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -2772,6 +2808,25 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "license": "MIT"
+    },
+    "node_modules/gitly": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/gitly/-/gitly-2.4.2.tgz",
+      "integrity": "sha512-ACX/tVQNBzI+0ZQOirG3ZHUDoW9xGQ0IxTY8sFEP0ja3Gi93ig3ow1JSidPs//+aYKTSnNs/pJi8CABcE+TDTQ==",
+      "dependencies": {
+        "axios": "^1.3.4",
+        "tar": "^6.1.13"
+      }
+    },
+    "node_modules/gitly/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -3718,7 +3773,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3726,7 +3780,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3770,7 +3823,6 @@
     },
     "node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -3841,7 +3893,6 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -3853,7 +3904,6 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -4604,6 +4654,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "dev": true,
@@ -5273,7 +5328,6 @@
     },
     "node_modules/tar": {
       "version": "6.1.13",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -5317,7 +5371,6 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-couchbase",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-couchbase",
-      "version": "0.6.1",
+      "version": "0.6.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
       },
       {
         "command": "vscode-couchbase.openSampleProjects",
-        "title": "New Project from Sample Template ...",
+        "title": "New Project from Template",
         "category": "Couchbase"
       },
       {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,14 @@
   "dependencies": {
     "axios": "^0.21.4",
     "couchbase": "^4.2.1",
+    "gitly": "^2.4.2",
     "keytar": "^7.7.0",
     "node-addon-api": "^6.0.0"
   },
   "activationEvents": [
     "onFileSystem:couchbase",
     "onCommand:vscode-couchbase.createClusterConnection",
+    "onCommand:vscode-couchbase.openSampleProjects",
     "onCommand:vscode-couchbase.refreshConnection",
     "onCommand:vscode-couchbase.deleteClusterConnection",
     "onCommand:vscode-couchbase.useClusterConnection",
@@ -353,6 +355,11 @@
         "icon": "images/create.svg"
       },
       {
+        "command": "vscode-couchbase.openSampleProjects",
+        "title": "New Project from Sample Template ...",
+        "category": "Couchbase"
+      },
+      {
         "command": "vscode-couchbase.openQueryNotebook",
         "title": "New SQL++ Notebook",
         "category": "Couchbase",
@@ -459,6 +466,10 @@
       "commandPalette": [
         {
           "command": "vscode-couchbase.refreshConnection",
+          "when": "false"
+        },
+        {
+          "command": "vscode-couchbase.openSampleProjects",
           "when": "false"
         },
         {
@@ -630,6 +641,10 @@
           "command": "vscode-couchbase.createClusterConnection",
           "when": "view == couchbase",
           "group": "navigation"
+        },
+        {
+          "command": "vscode-couchbase.openSampleProjects",
+          "when": "view == couchbase"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -906,8 +906,17 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             const projectUri = vscode.Uri.joinPath(fileUris[0], projectName);
-            const repoUrl = `couchbase-examples/${message.repo}`;
+            try {
+              // test if the project location already exists, if so, show error message
+              // fs.stat will throw an error if the file does not exist
+              await vscode.workspace.fs.stat(projectUri);
+              vscode.window.showErrorMessage("Selected project location already exists, please choose another location.");
+              return;
+            } catch {
+              // do nothing, project location does not exist
+            }
 
+            const repoUrl = `couchbase-examples/${message.repo}`;
             await gitly(repoUrl, projectUri.path, { throw: true });
 
             vscode.window.showInformationMessage(``);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -937,7 +937,7 @@ export function activate(context: vscode.ExtensionContext) {
           context.subscriptions
         );
       } catch (err) {
-        logger.error("Failed to open Query Workbench");
+        logger.error("Failed to open sample projects");
         logger.debug(err);
       }
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -910,7 +910,7 @@ export function activate(context: vscode.ExtensionContext) {
               // test if the project location already exists, if so, show error message
               // fs.stat will throw an error if the file does not exist
               await vscode.workspace.fs.stat(projectUri);
-              vscode.window.showErrorMessage("Selected project location already exists, please choose another location.");
+              vscode.window.showErrorMessage("Selected project location already has a project with same name, please choose a different location.", { modal: true });
               return;
             } catch {
               // do nothing, project location does not exist

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -932,6 +932,7 @@ export function activate(context: vscode.ExtensionContext) {
                 );
                 break;
             }
+            panel.dispose();
           },
           undefined,
           context.subscriptions

--- a/src/webViews/sampleProjects.webview.ts
+++ b/src/webViews/sampleProjects.webview.ts
@@ -1,0 +1,112 @@
+export function getSampleProjects(): string {
+  return `
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <title>Couchbase Sample Projects</title>
+            <style>
+                h1 {
+                    font-size: 24px;
+                }
+                h3 {
+                    font-size: 18px;
+                }
+                ul {
+                    list-style: none;
+                    margin: 0px;
+                    padding-left: 0;
+                }
+                li {
+                    white-space: nowrap;
+                }
+            </style>
+        </head>
+        <body>
+            <h1>Sample Projects</h1>
+            <br/>
+            <h3>Java</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('java-springdata-quickstart')">
+                        <span>Create Spring Data CRUD project</span>
+                    </button>
+                </li>
+                <li>
+                    <button onclick="getSample('java-springboot-quickstart')">
+                        <span>Create Spring Boot CRUD project</span>
+                    </button>
+                </li>
+                <li>
+                    <button onclick="getSample('java-transactions-quickstart')">
+                        <span>Create Key-Value Transaction Demo project</span>
+                    </button>
+                </li>
+            </ul>
+            <h3>NodeJS</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('ottomanjs-quickstart')">
+                        <span>Create Ottoman CRUD project</span>
+                    </button>
+                </li>
+                <li>
+                    <button onclick="getSample('nodejs-quickstart')">
+                        <span>Create NodeJS CRUD project</span>
+                    </button>
+                </li>
+                <li>
+                    <button onclick="getSample('nextjs-quickstart')">
+                        <span>Create NextJS CRUD project</span>
+                    </button>
+                </li>
+            </ul>
+            <h3>.NET</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('aspnet-quickstart')">
+                        <span>Create ASP.NET CRUD project</span>
+                    </button>
+                </li>
+                <li>
+                    <button onclick="getSample('aspnet-quickstart-minapi')">
+                        <span>Create ASP.NET Minimum API CRUD project</span>
+                    </button>
+                </li>
+            </ul>
+            <h3>Python</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('python-quickstart')">
+                        <span>Create Flask CRUD project</span>
+                    </button>
+                </li>
+            </ul>
+            <h3>Golang</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('golang-quickstart')">
+                        <span>Create Golang CRUD project</span>
+                    </button>
+                </li>
+            </ul>
+            <h3>Scala</h3>
+            <ul>
+                <li>
+                    <button onclick="getSample('scala-quickstart')">
+                        <span>Create Akka CRUD project</span>
+                    </button>
+                </li>
+            </ul>
+            <script>
+                function getSample(sampleName) {
+                    const vscode = acquireVsCodeApi();
+                    vscode.postMessage({
+                        repo: sampleName
+                    });
+                }
+            </script>
+        </body>
+        </html>
+     `;
+}

--- a/src/webViews/sampleProjects.webview.ts
+++ b/src/webViews/sampleProjects.webview.ts
@@ -99,8 +99,8 @@ export function getSampleProjects(): string {
                 </li>
             </ul>
             <script>
+                const vscode = acquireVsCodeApi();
                 function getSample(sampleName) {
-                    const vscode = acquireVsCodeApi();
                     vscode.postMessage({
                         repo: sampleName
                     });

--- a/src/webViews/sampleProjects.webview.ts
+++ b/src/webViews/sampleProjects.webview.ts
@@ -1,112 +1,158 @@
 export function getSampleProjects(): string {
   return `
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8" />
-            <title>Couchbase Sample Projects</title>
-            <style>
-                h1 {
-                    font-size: 24px;
-                }
-                h3 {
-                    font-size: 18px;
-                }
-                ul {
-                    list-style: none;
-                    margin: 0px;
-                    padding-left: 0;
-                }
-                li {
-                    white-space: nowrap;
-                }
-            </style>
-        </head>
-        <body>
-            <h1>Sample Projects</h1>
-            <br/>
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <title>Couchbase Sample Projects</title>
+        <style>
+          body {
+            margin: 0;
+            padding: 50px;
+            font-family: Arial, sans-serif;
+          }
+  
+          h1 {
+            font-size: 32px;
+          }
+  
+          h3 {
+            font-size: 24px;
+          }
+  
+          ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+          }
+  
+          li {
+            margin-bottom: 10px;
+          }
+  
+          li button {
+            background: none;
+            border: none;
+            color: var(--vscode-textLink-foreground);;
+            cursor: pointer;
+            padding: 0;
+            margin: 0;
+            font-size: 16px;
+            text-decoration: underline;
+            text-align: left;
+          }
+  
+          .projects-container {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            gap: 20px;
+          }
+  
+          .project-column {
+            flex-basis: 48%;
+          }
+        </style>
+      </head>
+      <body>
+        <h1>Sample Projects</h1>
+        <br/>
+        <div class="projects-container">
+          <div class="project-column">
             <h3>Java</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('java-springdata-quickstart')">
-                        <span>Create Spring Data CRUD project</span>
-                    </button>
-                </li>
-                <li>
-                    <button onclick="getSample('java-springboot-quickstart')">
-                        <span>Create Spring Boot CRUD project</span>
-                    </button>
-                </li>
-                <li>
-                    <button onclick="getSample('java-transactions-quickstart')">
-                        <span>Create Key-Value Transaction Demo project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('java-springdata-quickstart')">
+                  <span>Create Spring Data CRUD project</span>
+                </button>
+              </li>
+              <li>
+                <button onclick="getSample('java-springboot-quickstart')">
+                  <span>Create Spring Boot CRUD project</span>
+                </button>
+              </li>
+              <li>
+                <button onclick="getSample('java-transactions-quickstart')">
+                  <span>Create Key-Value Transaction Demo project</span>
+                </button>
+              </li>
             </ul>
+          </div>
+          <div class="project-column">
             <h3>NodeJS</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('ottomanjs-quickstart')">
-                        <span>Create Ottoman CRUD project</span>
-                    </button>
-                </li>
-                <li>
-                    <button onclick="getSample('nodejs-quickstart')">
-                        <span>Create NodeJS CRUD project</span>
-                    </button>
-                </li>
-                <li>
-                    <button onclick="getSample('nextjs-quickstart')">
-                        <span>Create NextJS CRUD project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('ottomanjs-quickstart')">
+                  <span>Create Ottoman CRUD project</span>
+                </button>
+              </li>
+              <li>
+                <button onclick="getSample('nodejs-quickstart')">
+                  <span>Create NodeJS CRUD project</span>
+                </button>
+              </li>
+              <li>
+                <button onclick="getSample('nextjs-quickstart')">
+                  <span>Create NextJS CRUD project</span>
+                </button>
+              </li>
             </ul>
+          </div>
+          <div class="project-column">
             <h3>.NET</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('aspnet-quickstart')">
-                        <span>Create ASP.NET CRUD project</span>
-                    </button>
-                </li>
-                <li>
-                    <button onclick="getSample('aspnet-quickstart-minapi')">
-                        <span>Create ASP.NET Minimum API CRUD project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('aspnet-quickstart')">
+                  <span>Create ASP.NET CRUD project</span>
+                </button>
+              </li>
+              <li>
+                <button onclick="getSample('aspnet-quickstart-minapi')">
+                  <span>Create ASP.NET Minimum API CRUD project</span>
+                </button>
+              </li>
             </ul>
+          </div>
+          <div class="project-column">
             <h3>Python</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('python-quickstart')">
-                        <span>Create Flask CRUD project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('python-quickstart')">
+                  <span>Create Flask CRUD project</span>
+                </button>
+              </li>
             </ul>
+          </div>
+          <div class="project-column">
             <h3>Golang</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('golang-quickstart')">
-                        <span>Create Golang CRUD project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('golang-quickstart')">
+                  <span>Create Golang CRUD project</span>
+                </button>
+              </li>
             </ul>
+          </div>
+          <div class="project-column">
             <h3>Scala</h3>
             <ul>
-                <li>
-                    <button onclick="getSample('scala-quickstart')">
-                        <span>Create Akka CRUD project</span>
-                    </button>
-                </li>
+              <li>
+                <button onclick="getSample('scala-quickstart')">
+                  <span>Create Akka CRUD project</span>
+                </button>
+              </li>
             </ul>
-            <script>
-                const vscode = acquireVsCodeApi();
-                function getSample(sampleName) {
-                    vscode.postMessage({
-                        repo: sampleName
-                    });
-                }
-            </script>
-        </body>
-        </html>
-     `;
+          </div>
+        </div>
+        <script>
+          const vscode = acquireVsCodeApi();
+          function getSample(sampleName) {
+            vscode.postMessage({
+              repo: sampleName
+            });
+          }
+        </script>
+      </body>
+      </html>
+    `;
 }


### PR DESCRIPTION
## Describe the problem this PR is solving
Adds a sample project workflow to allow extension uses to clone a Couchbase sample project and open / add it to their workspace. The extension asks for a project name and local folder to put the example then downloads the example. Once the example has been downloaded, the extension asks if they would like to open the example or add to the current workspace.

- Closes #139 

## Short description of the changes
- Adds gitly as extension dependency
- Add and wire up new action in package.json & extension.js
- Add webview that shows a list of sample projects grouped by language
- Add workflow to the click event of selecting one of the examples

TODO:
- [x] Improve styling of sample webview