### PR TITLE
DA#214: BugFix: Save the notebook with n1qlnb, n1ql or sqlpp

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
         "displayName": "SQL++ Query",
         "selector": [
           {
-            "filenamePattern": "*.n1qlnb"
+            "filenamePattern": "*.{n1qlnb,sqlpp,n1ql}"
           }
         ]
       }


### PR DESCRIPTION
Error when trying to save a SQL++ notebook to a file with a .sqlpp extension.

Steps to reproduce

Create a SQL++ notebook.
Add content to it.
Try to save
Enter a filename like demo-notebook.sqlpp
If possible, provide a recipe for reproducing the error.
What did you expect to see?
File saved successfully.

What did you see instead?
Error message:
vscode notebook issue error

What version did you use?
VSCode Version: 1.72.0
Extension Version: 0.2.0

