### PR TITLE
Add logic to update tools version + keywords for tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-couchbase",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-couchbase",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@chatscope/chat-ui-kit-styles": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-couchbase",
   "displayName": "Couchbase",
   "description": "",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "vscode": "^1.63.1"
   },
@@ -19,6 +19,7 @@
     "type": "git",
     "url": "https://github.com/couchbaselabs/VSCode-Couchbase.git"
   },
+  "keywords": ["Database", "Databases", "DBaaS", "Capella", "JSON"],
   "preview": false,
   "icon": "images/couchbase.png",
   "scripts": {

--- a/src/handlers/dependenciesUtil.ts
+++ b/src/handlers/dependenciesUtil.ts
@@ -1,0 +1,128 @@
+import * as path from "path";
+import * as fs from "fs";
+import { logger } from "../logger/logger";
+import { config } from "./versionConfig";
+
+class DependenciesUtil {
+    public static readonly VERSION_FILE = config.VERSION_FILE;
+
+    public static readonly CBMIGRATE_KEY = config.CBMIGRATE_KEY;
+    public static readonly TOOLS_KEY = config.TOOLS_KEY;
+    public static readonly SHELL_KEY = config.SHELL_KEY;
+    public static readonly CBIMPORT_EXPORT_KEY = config.CBIMPORT_EXPORT_KEY;
+
+    public static readonly TOOLS_VERSION = config.TOOLS_VERSION;
+
+    public static readonly CBMIGRATE_VERSION = config.CBMIGRATE_VERSION;
+    public static readonly SHELL_VERSION = config.SHELL_VERSION;
+    public static readonly CBIMPORT_EXPORT_VERSION =
+        config.CBIMPORT_EXPORT_VERSION;
+
+    public static createVersioningFile(directoryPath: string): void {
+        const filePath = path.join(
+            directoryPath,
+            DependenciesUtil.VERSION_FILE
+        );
+        if (!fs.existsSync(filePath)) {
+            DependenciesUtil.constructVersionFile(filePath);
+        }
+    }
+
+    private static constructVersionFile(filePath: string) {
+        // Temporarily setting tools version here as we are not using these tools as of now
+        const propertiesContent = `${DependenciesUtil.TOOLS_KEY}=${DependenciesUtil.TOOLS_VERSION}\n${DependenciesUtil.SHELL_KEY}=\n${DependenciesUtil.CBIMPORT_EXPORT_KEY}=\n${DependenciesUtil.CBMIGRATE_KEY}=\n`;
+
+        try {
+            fs.writeFileSync(filePath, propertiesContent, {
+                encoding: "utf-8",
+            });
+            logger.info("CB Tool Versions file created successfully.");
+        } catch (e) {
+            console.error("Failed to create the config file, error: ", e);
+            throw e;
+        }
+    }
+
+    public static getPropertyValue(
+        directoryPath: string,
+        propertyName: string
+    ): string | null {
+        const filePath = path.join(
+            directoryPath,
+            DependenciesUtil.VERSION_FILE
+        );
+        try {
+            const fileContent = fs.readFileSync(filePath, {
+                encoding: "utf-8",
+            });
+            if (fileContent) {
+                const properties =
+                    DependenciesUtil.parseVersionFile(fileContent);
+                const value = properties[propertyName];
+                return value && value.trim() ? value : null;
+            } else {
+                return null;
+            }
+        } catch (e) {
+            console.error(e);
+            return null;
+        }
+    }
+
+    public static setPropertyValue(
+        directoryPath: string,
+        propertyName: string,
+        value: string
+    ) {
+        const filePath = path.join(
+            directoryPath,
+            DependenciesUtil.VERSION_FILE
+        );
+        try {
+            const fileContent = fs.readFileSync(filePath, {
+                encoding: "utf-8",
+            });
+            let lines = fileContent.split(/\r?\n/);
+
+            const updatedLines = lines.map((line) => {
+                if (line.startsWith(propertyName + "=")) {
+                    return `${propertyName}=${value}`;
+                }
+                return line;
+            });
+            fs.writeFileSync(filePath, updatedLines.join("\n"), {
+                encoding: "utf-8",
+            });
+        } catch (e) {
+            console.error("Error occurred while setting the property value", e);
+            return null;
+        }
+    }
+
+    private static parseVersionFile(
+        fileContent: string
+    ): Record<string, string> {
+        const properties: Record<string, string> = {};
+        fileContent.split("\n").forEach((line) => {
+            const index = line.indexOf("=");
+            if (index > -1) {
+                const key = line.substring(0, index).trim();
+                const value = line.substring(index + 1).trim();
+                properties[key] = value;
+            }
+        });
+        return properties;
+    }
+
+    public static deleteFolder(folderPath: string): void {
+        try {
+            fs.rmdirSync(folderPath, { recursive: true });
+        } catch (error) {
+            logger.error(
+                `An error occurred while deleting the folder: ${folderPath}, error: ${error}`
+            );
+        }
+    }
+}
+
+export default DependenciesUtil;

--- a/src/handlers/handleCLIDownloader.ts
+++ b/src/handlers/handleCLIDownloader.ts
@@ -14,6 +14,7 @@ import * as fs from "fs";
 import axios from "axios";
 import decompress from "decompress";
 import { logger } from "../logger/logger";
+import DependenciesUtil from "./dependenciesUtil";
 
 class DependenciesDownloader {
     private readonly TOOL_SHELL = "shell";
@@ -275,22 +276,74 @@ class DependenciesDownloader {
         return map;
     }
 
+    public cleanOldVersions(
+        extensionPath: string,
+        toolsPath: string,
+        downloads: Map<string, ToolSpec>
+    ) {
+        logger.info("Cleaning up older tools versions if update required");
+        const shell: ToolSpec | undefined = downloads.get(this.TOOL_SHELL);
+        if (shell == undefined) {
+            return;
+        }
+        if (
+            this.isInstalled(toolsPath, shell, CBToolsType.SHELL) &&
+            (
+                DependenciesUtil.SHELL_VERSION !==
+                DependenciesUtil.getPropertyValue(
+                    extensionPath,
+                    DependenciesUtil.SHELL_KEY
+                )
+            )
+        ) {
+            logger.info(
+                "A new version of Couchbase Shell is available. Removing local version and downloading the new one"
+            );
+            DependenciesUtil.deleteFolder(
+                toolsPath + path.sep + shell.getInstallationPath()
+            );
+
+
+        }
+        const cbimport_export: ToolSpec | undefined = downloads.get(this.TOOL_IMPORT_EXPORT);
+        if (cbimport_export == undefined) {
+            return;
+        }
+        if (this.isInstalled(toolsPath, cbimport_export, CBToolsType.CB_EXPORT) && (DependenciesUtil.CBIMPORT_EXPORT_VERSION !== DependenciesUtil.getPropertyValue(extensionPath, DependenciesUtil.CBIMPORT_EXPORT_KEY))) {
+            logger.info("A new version of Couchbase CB Import/Export is available. Removing local version and downloading the new one");
+            DependenciesUtil.deleteFolder(
+                toolsPath + path.sep + cbimport_export.getInstallationPath()
+            );
+        }
+        const cbMigrate: ToolSpec | undefined = downloads.get(this.TOOL_MDB_MIGRATE);
+        if (cbMigrate == undefined) {
+            return;
+        }
+        if (this.isInstalled(toolsPath, cbMigrate, CBToolsType.CB_MIGRATE) && (DependenciesUtil.CBMIGRATE_VERSION !== DependenciesUtil.getPropertyValue(extensionPath, DependenciesUtil.CBMIGRATE_KEY))) {
+            logger.info("A new version of Couchbase CBMigrate is available. Removing local version and downloading the new one");
+            DependenciesUtil.deleteFolder(
+                toolsPath + path.sep + cbMigrate.getInstallationPath()
+            );
+        }
+    }
+
     public handleCLIDownloader = () => {
         const extensionPath = path.join(
             __filename,
             "..",
             "cb-vscode-extension"
         );
+        DependenciesUtil.createVersioningFile(extensionPath);
         createFolder(extensionPath);
         const toolsPath = path.join(extensionPath, "tools");
         createFolder(toolsPath);
         const osArch = OSUtil.getOSArch();
         const downloads: Map<string, ToolSpec> = this.getDownloadList(osArch);
+        this.cleanOldVersions(extensionPath, toolsPath, downloads);
         // Installs the tools if not already installed
-        this.manageShellInstallation(downloads, toolsPath);
-        this.manageCbMigrateInstallation(downloads, toolsPath);
-        this.manageDataImportExportInstallation(downloads, toolsPath);
-
+        this.manageShellInstallation(downloads, toolsPath, extensionPath);
+        this.manageCbMigrateInstallation(downloads, toolsPath, extensionPath);
+        this.manageDataImportExportInstallation(downloads, toolsPath, extensionPath);
     };
 
     private setToolActive(
@@ -307,7 +360,7 @@ class DependenciesDownloader {
         });
     }
 
-    public downloadAndUnzip(targetDir: string, spec: ToolSpec) {
+    public downloadAndUnzip(targetDir: string, spec: ToolSpec, configFolder: string, key: string, value: string) {
         try {
             createFolder(targetDir);
             const fileName = spec
@@ -327,6 +380,7 @@ class DependenciesDownloader {
                 });
             });
             this.setToolActive(ToolStatus.AVAILABLE, targetDir, spec);
+            DependenciesUtil.setPropertyValue(configFolder, key, value)
         } catch (e) {
             this.setToolActive(ToolStatus.NOT_AVAILABLE, "", spec);
             logger.error(e);
@@ -351,7 +405,11 @@ class DependenciesDownloader {
         return fs.existsSync(toolPath);
     }
 
-    public manageShellInstallation(downloads: Map<string, ToolSpec>, toolsPath: string): void {
+    public manageShellInstallation(
+        downloads: Map<string, ToolSpec>,
+        toolsPath: string,
+        extensionPath: string
+    ): void {
         const shell = downloads.get(this.TOOL_SHELL);
         if (shell === undefined) {
             return;
@@ -374,14 +432,18 @@ class DependenciesDownloader {
             // Avoiding 2 threads to install the same thing at the same time
             logger.info("Downloading CB Shell.");
             shellTool.status = ToolStatus.DOWNLOADING;
-            this.downloadAndUnzip(shellPath, shell);
+            this.downloadAndUnzip(shellPath, shell, extensionPath, DependenciesUtil.SHELL_KEY, DependenciesUtil.SHELL_VERSION);
         } else {
             logger.debug("CBShell is already installed");
             this.setToolActive(ToolStatus.AVAILABLE, shellPath, shell);
         }
     }
 
-    public manageCbMigrateInstallation(downloads: Map<string, ToolSpec>, toolsPath: string): void {
+    public manageCbMigrateInstallation(
+        downloads: Map<string, ToolSpec>,
+        toolsPath: string,
+        extensionPath: string
+    ): void {
         const cbMigrate = downloads.get(this.TOOL_MDB_MIGRATE);
         if (cbMigrate === undefined) {
             return;
@@ -392,7 +454,7 @@ class DependenciesDownloader {
         );
         const cbMigrateTool = CBTools.getTool(CBToolsType.CB_MIGRATE);
         const cbMigrateStatus = cbMigrateTool.status;
-        const cbMigrateDownloadsMap = downloads.get(this.TOOL_SHELL);
+        const cbMigrateDownloadsMap = downloads.get(this.TOOL_MDB_MIGRATE);
         if (cbMigrateDownloadsMap === undefined) {
             return;
         }
@@ -407,14 +469,18 @@ class DependenciesDownloader {
             // Avoiding 2 threads to install the same thing at the same time
             logger.info("Downloading CB Migrate.");
             cbMigrateTool.status = ToolStatus.DOWNLOADING;
-            this.downloadAndUnzip(cbMigratePath, cbMigrate);
+            this.downloadAndUnzip(cbMigratePath, cbMigrate, extensionPath, DependenciesUtil.CBMIGRATE_KEY, DependenciesUtil.CBMIGRATE_VERSION);
         } else {
             logger.debug("CBMigrate is already installed");
             this.setToolActive(ToolStatus.AVAILABLE, cbMigratePath, cbMigrate);
         }
     }
 
-    public manageDataImportExportInstallation(downloads: Map<string, ToolSpec>, toolsPath: string): void {
+    public manageDataImportExportInstallation(
+        downloads: Map<string, ToolSpec>,
+        toolsPath: string,
+        extensionPath: string
+    ): void {
         const cbImport: ToolSpec | undefined = downloads.get(
             this.TOOL_IMPORT_EXPORT
         );
@@ -448,14 +514,12 @@ class DependenciesDownloader {
             cbExportTool.status = ToolStatus.DOWNLOADING;
             cbImportTool.status = ToolStatus.DOWNLOADING;
 
-            this.downloadAndUnzip(cbImportDir, cbImport);
+            this.downloadAndUnzip(cbImportDir, cbImport, extensionPath, DependenciesUtil.CBIMPORT_EXPORT_KEY, DependenciesUtil.CBIMPORT_EXPORT_VERSION);
         } else {
             logger.info("CB Import/Export is already installed");
             this.setToolActive(ToolStatus.AVAILABLE, cbImportDir, cbImport);
         }
     }
-
-
 
     // This is a test function, keeping this here to check for any specific downloaded CLI tool
     /* public runFile(targetDir:string) {

--- a/src/handlers/versionConfig.ts
+++ b/src/handlers/versionConfig.ts
@@ -1,0 +1,11 @@
+export const config = {
+    VERSION_FILE: "cb_tool_versions.txt",
+    CBMIGRATE_KEY: "cbmigrate",
+    TOOLS_KEY: "tools",
+    SHELL_KEY: "shell",
+    CBIMPORT_EXPORT_KEY: "cbimport_export",
+    TOOLS_VERSION: "7.2",
+    CBMIGRATE_VERSION: "1",
+    SHELL_VERSION: "1",
+    CBIMPORT_EXPORT_VERSION: "7.2",
+};


### PR DESCRIPTION
Added the code to update tools version when required via a config file which maintains current version of tools.
Also updated the tags using keywords.

Note: Need to do one round of testing on a windows machine & also there are some warnings while using some fs methods like rmDir, we will need to update this once higher version of Node is merged.
```DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead```
