### PR TITLE
Update Cache service to handle refresh + add few tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+"use strict";
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+    testMatch: ['**/src/util/**/*.test.(ts|tsx)'],
+    transform: {
+        '^.+\\.(ts|tsx)$': 'ts-jest',
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-couchbase",
-  "version": "1.3.0",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-couchbase",
-      "version": "1.3.0",
+      "version": "1.2.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@chatscope/chat-ui-kit-styles": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-couchbase",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-couchbase",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@chatscope/chat-ui-kit-styles": "^1.4.0",
@@ -57,7 +57,8 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/traverse": "^7.22.8",
         "@types/glob": "^7.2.0",
-        "@types/mocha": "^8.2.3",
+        "@types/jest": "^29.5.12",
+        "@types/mocha": "^10.0.6",
         "@types/mongodb": "^4.0.7",
         "@types/node": "^12.20.42",
         "@types/react": "^18.2.6",
@@ -77,6 +78,7 @@
         "eslint": "^7.32.0",
         "file-loader": "^6.2.0",
         "glob": "^7.2.0",
+        "jest": "^29.7.0",
         "mocha": "^9.2.2",
         "node-loader": "^2.0.0",
         "node-sass": "^9.0.0",
@@ -87,6 +89,7 @@
         "sass": "^1.64.1",
         "sass-loader": "^13.3.2",
         "style-loader": "^3.3.3",
+        "ts-jest": "^29.1.2",
         "ts-loader": "^8.3.0",
         "typescript": "^5.0.4",
         "vsce": "^2.6.3",
@@ -102,7 +105,6 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -129,22 +131,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
+      "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
-        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.4",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.5",
-        "@babel/parser": "^7.23.5",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5",
+        "@babel/helpers": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -160,89 +161,16 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/core/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/core/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/core/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@babel/core/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@babel/core/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
@@ -250,33 +178,19 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/core/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/generator": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
+      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.5",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -308,14 +222,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -511,9 +425,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -631,29 +545,29 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
+      "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5"
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -724,9 +638,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -799,6 +713,18 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1021,6 +947,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+      "integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2046,14 +1987,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2144,20 +2085,20 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+      "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
+        "@babel/code-frame": "^7.24.1",
+        "@babel/generator": "^7.24.1",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.5",
-        "@babel/types": "^7.23.5",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2165,66 +2106,16 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/traverse/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/traverse/node_modules/globals": {
@@ -2236,31 +2127,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/traverse/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/types": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
-      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
@@ -2270,6 +2140,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@chatscope/chat-ui-kit-styles": {
       "version": "1.4.0",
@@ -2512,14 +2388,418 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -2534,9 +2814,10 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2556,12 +2837,13 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -2693,6 +2975,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "dev": true,
@@ -2702,6 +2990,24 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -2721,6 +3027,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/cacheable-request": {
@@ -2782,6 +3129,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.3.tgz",
@@ -2794,6 +3150,40 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -2828,9 +3218,10 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "8.2.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true
     },
     "node_modules/@types/mongodb": {
       "version": "4.0.7",
@@ -2894,6 +3285,12 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
     },
     "node_modules/@types/stream-chain": {
       "version": "2.0.3",
@@ -2959,6 +3356,21 @@
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -3470,6 +3882,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
@@ -3638,6 +4077,27 @@
         "typed-rest-client": "^1.8.4"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.1.3.tgz",
@@ -3708,6 +4168,62 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
@@ -3754,6 +4270,45 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/bail": {
@@ -3890,6 +4445,27 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/bson": {
@@ -4171,6 +4747,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4274,6 +4859,27 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
@@ -4745,6 +5351,16 @@
         "y18n": "^3.2.0"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -4753,6 +5369,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4865,6 +5487,12 @@
       "version": "1.1.0",
       "license": "ISC"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/core-js-compat": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
@@ -4941,6 +5569,27 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
       "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -5389,6 +6038,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
@@ -5400,6 +6063,15 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -5471,6 +6143,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -5489,6 +6170,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -5632,6 +6322,18 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.609.tgz",
       "integrity": "sha512-ihiCP7PJmjoGNuLpl7TjNA8pCQWu09vGyjlPYw1Rqww4gvNuCcmvl+44G+2QyJ6S2K4o+wbTS++Xz0YN8Q9ERw==",
       "dev": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6066,11 +6768,83 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/extend": {
@@ -6136,6 +6910,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/fd-slicer": {
@@ -6550,7 +7333,6 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6573,6 +7355,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/get-stdin": {
@@ -7026,6 +7817,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
@@ -7093,6 +7890,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -7437,6 +8243,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
@@ -7689,6 +8504,722 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+      "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@babel/code-frame": {
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "dev": true,
@@ -7868,6 +9399,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -7994,6 +9534,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -8118,6 +9664,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
       "dev": true,
@@ -8163,6 +9715,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
       }
     },
     "node_modules/map-obj": {
@@ -9387,6 +10948,12 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
     "node_modules/node-loader": {
       "version": "2.0.0",
       "dev": true,
@@ -9855,6 +11422,18 @@
         "which": "bin/which"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npmlog": {
       "version": "6.0.2",
       "license": "ISC",
@@ -10268,6 +11847,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "dev": true,
@@ -10497,6 +12085,38 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/prismjs": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
@@ -10532,6 +12152,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/prop-types": {
@@ -10577,6 +12210,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -11276,6 +12925,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/responselike": {
       "version": "2.0.1",
       "dev": true,
@@ -11683,6 +13341,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11845,6 +13509,27 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -11907,6 +13592,19 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -12008,6 +13706,15 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dependencies": {
         "is-natural-number": "^4.0.1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-indent": {
@@ -12241,6 +13948,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -12261,6 +13982,12 @@
       "engines": {
         "node": ">=8.17.0"
       }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
     },
     "node_modules/to-buffer": {
       "version": "1.1.1",
@@ -12345,6 +14072,58 @@
       "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==",
       "dev": true
     },
+    "node_modules/ts-jest": {
+      "version": "29.1.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-loader": {
       "version": "8.4.0",
       "dev": true,
@@ -12412,6 +14191,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -12733,6 +14521,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -12873,6 +14675,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/warning": {
@@ -13186,6 +14997,19 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "compile:views": "webpack --mode development",
     "watch:extension": "tsc -watch -p ./",
     "watch:views": "webpack --watch --mode development",
-    "test": "node ./out/test/runTest.js",
-    "testCache": "jest",
+    "test": "node ./out/test/runTest.js && jest",
     "format": "prettier 'src/**/*.ts' --write",
     "lint": "eslint src --ext ts --fix",
     "pretest": "npm run compile:extension"
@@ -650,12 +649,6 @@
         "title": "Show iQ settings",
         "category": "Couchbase",
         "icon": "$(gear)"
-      },
-      {
-        "command": "vscode-couchbase.forceUpdateCache",
-        "title": "Forced update cache",
-        "category": "couchbase",
-        "icon": "$(cloud-download)"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-couchbase",
   "displayName": "Couchbase",
   "description": "",
-  "version": "1.3.0",
+  "version": "1.2.5",
   "engines": {
     "vscode": "^1.63.1"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-couchbase",
   "displayName": "Couchbase",
   "description": "",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "engines": {
     "vscode": "^1.63.1"
   },
@@ -37,6 +37,7 @@
     "watch:extension": "tsc -watch -p ./",
     "watch:views": "webpack --watch --mode development",
     "test": "node ./out/test/runTest.js",
+    "testCache": "jest",
     "format": "prettier 'src/**/*.ts' --write",
     "lint": "eslint src --ext ts --fix",
     "pretest": "npm run compile:extension"
@@ -47,7 +48,8 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/traverse": "^7.22.8",
     "@types/glob": "^7.2.0",
-    "@types/mocha": "^8.2.3",
+    "@types/jest": "^29.5.12",
+    "@types/mocha": "^10.0.6",
     "@types/mongodb": "^4.0.7",
     "@types/node": "^12.20.42",
     "@types/react": "^18.2.6",
@@ -67,6 +69,7 @@
     "eslint": "^7.32.0",
     "file-loader": "^6.2.0",
     "glob": "^7.2.0",
+    "jest": "^29.7.0",
     "mocha": "^9.2.2",
     "node-loader": "^2.0.0",
     "node-sass": "^9.0.0",
@@ -77,6 +80,7 @@
     "sass": "^1.64.1",
     "sass-loader": "^13.3.2",
     "style-loader": "^3.3.3",
+    "ts-jest": "^29.1.2",
     "ts-loader": "^8.3.0",
     "typescript": "^5.0.4",
     "vsce": "^2.6.3",
@@ -431,6 +435,12 @@
         "icon": "images/create.svg"
       },
       {
+        "command": "vscode-couchbase.refreshCache",
+        "title": "Refresh Cache",
+        "category": "Couchbase",
+        "icon": "images/create.svg"
+      },
+      {
         "command": "vscode-couchbase.refreshConnection",
         "title": "Refresh Cluster Connection",
         "category": "Couchbase"
@@ -706,6 +716,10 @@
           "when": "false"
         },
         {
+          "command": "vscode-couchbase.refreshCache",
+          "when": "false"
+        },
+        {
           "command": "vscode-couchbase.openSampleProjects",
           "when": "false"
         },
@@ -860,6 +874,10 @@
           "command": "vscode-couchbase.deleteClusterConnection",
           "when": "view == couchbase && viewItem == active_connection",
           "group": "activeSecondary@2"
+        },
+        {
+          "command": "vscode-couchbase.refreshCache",
+          "when": "view == couchbase && viewItem == active_connection"
         },
         {
           "command": "vscode-couchbase.openQueryNotebook",

--- a/src/commands/documents/createDocument.ts
+++ b/src/commands/documents/createDocument.ts
@@ -100,6 +100,7 @@ export const createDocument = async (node: CollectionNode, memFs: MemFS, uriToCa
     let documentContent = Buffer.from("{}");
     let patternCnt = 0;
     try {
+        // TODO: Use Collection Schema Cache to fetch patternCnt
         let query = "INFER `" + node.bucketName + "`.`" + node.scopeName + "`.`" + node.collectionName + "` WITH {\"sample_size\": 2000}";
         const result = await connection?.cluster?.query(query);
         patternCnt = result?.rows[0].length || 0;

--- a/src/commands/documents/removeDocument.ts
+++ b/src/commands/documents/removeDocument.ts
@@ -20,8 +20,10 @@ import { MemFS } from "../../util/fileSystemProvider";
 import { Memory } from "../../util/util";
 import { IConnection } from "../../types/IConnection";
 import { Constants } from "../../util/constants";
+import { CacheService } from "../../util/cacheService/cacheService";
+import { CouchbaseRestAPI } from "../../util/apis/CouchbaseRestAPI";
 
-export const removeDocument = async (node: DocumentNode, uriToCasMap: Map<string, string>, memFs: MemFS) => {
+export const removeDocument = async (node: DocumentNode, uriToCasMap: Map<string, string>, memFs: MemFS, cacheService: CacheService) => {
     const connection = Memory.state.get<IConnection>(Constants.ACTIVE_CONNECTION);
     if (!connection) {
         return;
@@ -45,6 +47,12 @@ export const removeDocument = async (node: DocumentNode, uriToCasMap: Map<string
         );
         memFs.delete(uri);
         uriToCasMap.delete(uri.toString());
+        const couchbaseRestAPI = new CouchbaseRestAPI(connection);
+        const KVCollectionCount: Map<string, number> = await couchbaseRestAPI.getKVDocumentCount(node.bucketName, node.scopeName);
+        const documentCountInCollection = KVCollectionCount.get(`kv_collection_item_count-${node.bucketName}-${node.scopeName}-${node.collectionName}`) ?? 0;
+        if (((documentCountInCollection - 1) < 2000)) {
+            await cacheService.updateCollectionSchemaCache(connection, node.bucketName, node.scopeName, node.collectionName, Constants.COLLECTION_CACHE_EXPIRY_DURATION, true);
+        }
     } catch (err) {
         if (!(err instanceof vscode.FileSystemError)) {
             logger.error(err);

--- a/src/commands/documents/removeDocument.ts
+++ b/src/commands/documents/removeDocument.ts
@@ -50,7 +50,7 @@ export const removeDocument = async (node: DocumentNode, uriToCasMap: Map<string
         const couchbaseRestAPI = new CouchbaseRestAPI(connection);
         const KVCollectionCount: Map<string, number> = await couchbaseRestAPI.getKVDocumentCount(node.bucketName, node.scopeName);
         const documentCountInCollection = KVCollectionCount.get(`kv_collection_item_count-${node.bucketName}-${node.scopeName}-${node.collectionName}`) ?? 0;
-        if (((documentCountInCollection - 1) < 2000)) {
+        if (((documentCountInCollection - 1) < Constants.INFER_SAMPLE_SIZE)) {
             await cacheService.updateCollectionSchemaCache(connection, node.bucketName, node.scopeName, node.collectionName, Constants.COLLECTION_CACHE_EXPIRY_DURATION, true);
         }
     } catch (err) {

--- a/src/commands/extensionCommands/commands.ts
+++ b/src/commands/extensionCommands/commands.ts
@@ -63,5 +63,4 @@ export namespace Commands {
     export const logoutIq: string = "vscode-couchbase.iq.logout";
     export const showIqSettings: string = "vscode-couchbase.iq.showSettings";
     export const newIqChat: string = "vscode-couchbase.iq.newChat";
-    export const forceUpdateCache: string = "vscode-couchbase.forceUpdateCache";
 }

--- a/src/commands/extensionCommands/commands.ts
+++ b/src/commands/extensionCommands/commands.ts
@@ -53,6 +53,7 @@ export namespace Commands {
     export const editDocumentFilter: string = "vscode-couchbase.editDocumentFilter";
     export const clearDocumentFilter: string = "vscode-couchbase.clearDocumentFilter";
     export const refreshClusterOverview: string = "vscode-couchbase.refreshClusterOverview";
+    export const refreshCache: string = "vscode-couchbase.refreshCache";
     export const checkAndCreatePrimaryIndex: string = "vscode-couchbase.checkAndCreatePrimaryIndex";
     export const dataExport: string = "vscode-couchbase.tools.dataExport";
     export const mdbMigrate: string = "vscode-couchbase.tools.mdbMigrate";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -663,11 +663,6 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand(Commands.forceUpdateCache, async () => {
-      cacheService.fullCache(true);
-    })
-  );
 }
 
 // this method is called when your extension is deactivated

--- a/src/handlers/handleSaveDocument.ts
+++ b/src/handlers/handleSaveDocument.ts
@@ -56,7 +56,7 @@ export const handleOnSaveTextDocument = async (document: vscode.TextDocument, ur
         const couchbaseRestAPI = new CouchbaseRestAPI(activeConnection);
         const KVCollectionCount: Map<string, number> = await couchbaseRestAPI.getKVDocumentCount(documentInfo.bucket, documentInfo.scope);
         const documentCountInCollection = KVCollectionCount.get(`kv_collection_item_count-${documentInfo.bucket}-${documentInfo.scope}-${documentInfo.collection}`) ?? 0;
-        if ((documentCountInCollection + 1) < 2000) {
+        if ((documentCountInCollection + 1) < Constants.INFER_SAMPLE_SIZE) {
             await cacheService.updateCollectionSchemaCache(activeConnection, documentInfo.bucket, documentInfo.scope, documentInfo.collection, Constants.COLLECTION_CACHE_EXPIRY_DURATION, true);
         }
     }

--- a/src/model/BucketNode.ts
+++ b/src/model/BucketNode.ts
@@ -22,6 +22,7 @@ import { ScopeSpec } from "couchbase";
 import InformationNode from "./InformationNode";
 import { logger } from "../logger/logger";
 import { getActiveConnection } from "../util/connections";
+import { CacheService } from "../../src/util/cacheService/cacheService"
 
 export class BucketNode implements INode {
   constructor(
@@ -29,7 +30,8 @@ export class BucketNode implements INode {
     public readonly connection: IConnection,
     public readonly bucketName: string,
     public readonly isScopesandCollections: boolean,
-    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public cacheService: CacheService
   ) { }
 
   public getTreeItem(): vscode.TreeItem {
@@ -76,7 +78,8 @@ export class BucketNode implements INode {
               scope.name,
               this.bucketName,
               scope.collections,
-              vscode.TreeItemCollapsibleState.None
+              vscode.TreeItemCollapsibleState.None,
+              this.cacheService
             )
           );
         });

--- a/src/model/ClusterConnectionNode.ts
+++ b/src/model/ClusterConnectionNode.ts
@@ -81,7 +81,7 @@ export class ClusterConnectionNode implements INode {
           )
         );
       });
-      this.cacheService.checkCacheTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
+      this.cacheService.refreshCacheOnTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
     } catch (err: any) {
       logger.error("Failed to load Buckets");
       logger.debug(err);

--- a/src/model/ClusterConnectionNode.ts
+++ b/src/model/ClusterConnectionNode.ts
@@ -23,14 +23,23 @@ import { BucketSettings } from "couchbase";
 import { getActiveConnection } from "../util/connections";
 import InformationNode from "./InformationNode";
 import { logger } from "../logger/logger";
+import { CacheService } from "../../src/util/cacheService/cacheService"
+import { Constants } from "../util/constants";
 
 export class ClusterConnectionNode implements INode {
   constructor(
     public readonly id: string,
-    public readonly connection: IConnection
-  ) { }
+    public readonly connection: IConnection,
+    public cacheService: CacheService
+  ) {
+    this._onDidChangeTreeData = new vscode.EventEmitter();
+    this.onDidChangeTreeData = this._onDidChangeTreeData.event;
+  }
 
   public isActive: Boolean = false;
+
+  private _onDidChangeTreeData: vscode.EventEmitter<any>;
+  public readonly onDidChangeTreeData: vscode.Event<any>;
 
   public getTreeItem(): vscode.TreeItem {
     const activeConnection = getActiveConnection();
@@ -43,7 +52,7 @@ export class ClusterConnectionNode implements INode {
       iconPath: {
         light: path.join(__filename, "..", "..", "images", this.isActive ? "" : "light", "cb-logo-icon.svg"),
         dark: path.join(__filename, "..", "..", "images", this.isActive ? "" : "dark", "cb-logo-icon.svg"),
-      }
+      },
     };
   }
 
@@ -67,10 +76,12 @@ export class ClusterConnectionNode implements INode {
             this.connection,
             bucket.name,
             isScopesandCollections,
-            vscode.TreeItemCollapsibleState.None
+            vscode.TreeItemCollapsibleState.None,
+            this.cacheService
           )
         );
       });
+      this.cacheService.checkCacheTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
     } catch (err: any) {
       logger.error("Failed to load Buckets");
       logger.debug(err);

--- a/src/model/CollectionNode.ts
+++ b/src/model/CollectionNode.ts
@@ -101,7 +101,7 @@ export default class CollectionNode implements INode {
     }
     const isQueryServicesEnable = hasQueryService(connection?.services);
     if (isQueryServicesEnable) {
-      this.cacheService.checkCacheTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
+      this.cacheService.refreshCacheOnTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
       documentList.push(indexItem);
       documentList.push(
         new SchemaDirectory(

--- a/src/model/CollectionNode.ts
+++ b/src/model/CollectionNode.ts
@@ -30,6 +30,9 @@ import { Commands } from "../commands/extensionCommands/commands";
 import { IndexDirectory } from "./IndexDirectory";
 import { logger } from "../logger/logger";
 import { CouchbaseRestAPI } from "../util/apis/CouchbaseRestAPI";
+import { CacheService } from "../../src/util/cacheService/cacheService"
+import { Constants } from "../util/constants";
+
 
 export default class CollectionNode implements INode {
   constructor(
@@ -41,7 +44,8 @@ export default class CollectionNode implements INode {
     public readonly collectionName: string,
     public readonly filter: boolean,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-    public limit: number = 10
+    public cacheService: CacheService,
+    public limit: number = 10,
   ) {
     vscode.workspace.fs.createDirectory(
       vscode.Uri.parse(
@@ -88,7 +92,8 @@ export default class CollectionNode implements INode {
       this.scopeName,
       this.collectionName,
       [],
-      vscode.TreeItemCollapsibleState.None
+      vscode.TreeItemCollapsibleState.None,
+      this.cacheService
     );
     const connection = getActiveConnection();
     if (!connection) {
@@ -96,6 +101,7 @@ export default class CollectionNode implements INode {
     }
     const isQueryServicesEnable = hasQueryService(connection?.services);
     if (isQueryServicesEnable) {
+      this.cacheService.checkCacheTimeout(Constants.BUCKET_CACHE_EXPIRY_DURATION, Constants.COLLECTION_CACHE_EXPIRY_DURATION, false);
       documentList.push(indexItem);
       documentList.push(
         new SchemaDirectory(
@@ -104,7 +110,8 @@ export default class CollectionNode implements INode {
           "Schema",
           this.bucketName,
           this.scopeName,
-          this.collectionName
+          this.collectionName,
+          this.cacheService
         )
       );
     }

--- a/src/model/SchemaDirectory.ts
+++ b/src/model/SchemaDirectory.ts
@@ -34,15 +34,15 @@ export class SchemaDirectory implements INode {
             if (!connection) {
                 return [];
             }
-            const result = await connection?.cluster?.query(query);
+            const queryResult = await connection?.cluster?.query(query);
             const schemaChildren: INode[] = [];
-            const patternCnt: number = result?.rows[0].length || 0;
-            if (!result) {
+            const patternCnt: number = queryResult?.rows[0].length || 0;
+            if (!queryResult) {
                 return []
             }
-            this.cacheService.updateCollectionSchemaCache(connection, this.bucketName, this.scopeName, this.collectionName, Constants.COLLECTION_CACHE_EXPIRY_DURATION, true, result);
+            this.cacheService.updateCollectionSchemaCache(connection, this.bucketName, this.scopeName, this.collectionName, Constants.COLLECTION_CACHE_EXPIRY_DURATION, true, queryResult);
             for (let i = 0; i < patternCnt; i++) {
-                const row = result?.rows[0][i];
+                const row = queryResult?.rows[0][i];
                 const childrenNode = this.treeTraversal(row.properties);
                 const patternDirectory = new SchemaNode(
                     `Pattern #${i + 1}`,

--- a/src/model/ScopeNode.ts
+++ b/src/model/ScopeNode.ts
@@ -26,6 +26,8 @@ import InformationNode from "./InformationNode";
 import { ParsingFailureError, PlanningFailureError } from "couchbase";
 import { hasQueryService } from "../util/common";
 import { CouchbaseRestAPI } from "../util/apis/CouchbaseRestAPI";
+import { CacheService } from "../../src/util/cacheService/cacheService"
+
 
 export class ScopeNode implements INode {
   constructor(
@@ -34,7 +36,8 @@ export class ScopeNode implements INode {
     public readonly scopeName: string,
     public readonly bucketName: string,
     public readonly collections: any[],
-    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public cacheService: CacheService 
   ) { }
 
   public getTreeItem(): vscode.TreeItem {
@@ -110,7 +113,8 @@ export class ScopeNode implements INode {
           this.bucketName,
           collection.name,
           filter !== "",
-          vscode.TreeItemCollapsibleState.None
+          vscode.TreeItemCollapsibleState.None,
+          this.cacheService
         );
         collectionList.push(collectionTreeItem);
       } catch (err: any) {

--- a/src/tools/MDBMigrate.ts
+++ b/src/tools/MDBMigrate.ts
@@ -47,7 +47,7 @@ export class MDBToCB {
                 cmd.push("--cb-username");
                 cmd.push(connection.username);
                 cmd.push("--cb-password");
-                cmd.push(password);
+                cmd.push("'" + password + "'");
                 cmd.push("--cb-bucket");
                 cmd.push(cbBucket);
                 cmd.push("--cb-scope");

--- a/src/util/cacheService/cacheService.test.ts
+++ b/src/util/cacheService/cacheService.test.ts
@@ -1,0 +1,382 @@
+import { IConnection } from "../../types/IConnection";
+import { CacheService } from "./cacheService";
+import { IBucketCache } from "./cacheService";
+import { IScopeCache } from "./cacheService";
+import { ICollectionCache } from "./cacheService";
+
+jest.mock(
+    "vscode",
+    () => ({
+        workspace: {
+            onDidChangeConfiguration: jest.fn(),
+            getConfiguration: jest.fn(() => ({
+                get: jest.fn(),
+            })),
+        },
+        window: {
+            createOutputChannel: jest.fn().mockReturnValue({
+                appendLine: jest.fn(),
+                show: jest.fn(),
+            }),
+        },
+
+    }),
+    { virtual: true }
+);
+
+jest.mock("../common", () => ({
+    ...jest.requireActual("../common"),
+    hasQueryService: jest.fn(() => true),
+}));
+
+jest.mock('../connections', () => {
+    const bucketManagerMock = {
+        getAllBuckets: jest.fn().mockResolvedValue([{ name: "exampleBucket" }]),
+    };
+    const collectionsMock = {
+        getAllScopes: jest.fn().mockResolvedValue([
+            { name: "exampleScope", collections: [{ name: "exampleCollection" }] },
+            { name: "exampleScope2", collections: [{ name: "exampleCollection" }] },
+        ]),
+    };
+
+    const mockCluster = {
+        buckets: () => bucketManagerMock,
+        bucket: jest.fn().mockImplementation((bucketName) => ({
+            collections: () => collectionsMock,
+        })),
+        query: jest.fn().mockResolvedValue({
+            rows: [{ properties: { exampleCollection: {} } }],
+        }),
+    };
+
+    return {
+        getActiveConnection: jest.fn().mockReturnValue({
+            url: "https://example.com",
+            username: "username",
+            connectionIdentifier: "someConnectionId",
+            isSecure: true,
+            cluster: mockCluster
+        })
+    };
+});
+
+
+// Helper method to create sample Bucket cache
+function createBucketCache(mockConnection: IConnection, bucketTimeStamp: Date, collectionTimeStamp: Date) {
+    const exampleCollectionCache: ICollectionCache = {
+        name: "exampleCollection",
+        scopeName: "exampleScope",
+        bucketName: "exampleBucket",
+        indexes: ["index1", "index2"],
+        timeStamp: collectionTimeStamp,
+    };
+
+    const exampleScopeCache: IScopeCache = {
+        collections: new Map([
+            ["exampleCollection", exampleCollectionCache],
+        ]),
+        name: "exampleScope",
+        bucketName: "exampleBucket",
+    };
+
+    const exampleBucketCache: IBucketCache = {
+        scopes: new Map([["exampleScope", exampleScopeCache]]),
+        name: "exampleBucket",
+        connection: mockConnection,
+        timeStamp: bucketTimeStamp,
+    };
+
+    return exampleBucketCache;
+}
+
+
+
+jest.setTimeout(20000);
+
+describe("Given CacheService is responsible for refreshing the caching of couchbase entities such as Buckets, Scopes, and Collections, it", () => {
+    const mockConnection: IConnection = {
+        url: "https://example.com",
+        username: "username",
+        connectionIdentifier: "someConnectionId",
+        isSecure: true,
+    };
+
+    let cacheService: CacheService;
+
+    beforeEach(async () => {
+
+
+        cacheService = new CacheService();
+        // Not mocking the Memory state calls associated with the methods loadCache, storeCache, instead mocked the whole method, as the below tests focuses mainly 
+        // on testing the refresh/update of the Cache and not on the implementation of loadCache/storeCache itself
+        jest.spyOn(cacheService, "loadCache").mockImplementation(() =>
+            Promise.resolve(true)
+        );
+        jest.spyOn(cacheService, "storeCache").mockResolvedValue();
+
+    });
+
+    it("should correctly handle refreshing of buckets older than 10minutes", async () => {
+        // Time stamp, more than ten minutes
+        const tenMinutesAgo = new Date(new Date().getTime() - 11 * 60 * 1000);
+
+        const exampleBucketCache = createBucketCache(mockConnection, tenMinutesAgo, tenMinutesAgo);
+        // Helper method to set this.BucketsData 
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+        await cacheService.checkCacheTimeout(10, 10, false);
+        // Helper method to get this.BucketsData
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is not equal to what it was 10minutes ago and scope cache is updated
+            expect(cacheTimeStamp).not.toEqual(tenMinutesAgo);
+            expect(updatedCache.scopes.size).toEqual(2);
+        }
+    });
+
+    it("should correctly handle not refreshing of buckets within 10minutes", async () => {
+        const currentTime = new Date(new Date().getTime());
+
+        const exampleBucketCache = createBucketCache(mockConnection, currentTime, currentTime);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.checkCacheTimeout(10, 10, false);
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is equal to what it was few minutes ago
+            expect(cacheTimeStamp).toEqual(currentTime);
+            expect(updatedCache.scopes.size).not.toEqual(2);
+        }
+    });
+
+    it("should correctly handle not refreshing of buckets within 10minutes", async () => {
+        const currentTime = new Date(new Date().getTime());
+
+        const exampleBucketCache = createBucketCache(mockConnection, currentTime, currentTime);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.checkCacheTimeout(10, 10, false);
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is equal to what it was few minutes ago
+            expect(cacheTimeStamp).toEqual(currentTime);
+            expect(updatedCache.scopes.size).not.toEqual(2);
+        }
+    });
+
+    it("should correctly handle refreshing of ONLY collection cache for buckets older than 10minutes", async () => {
+        // Time stamp, more than ten minutes
+        const tenMinutesAgo = new Date(new Date().getTime() - 15 * 60 * 1000);
+        const currentTime = new Date(new Date().getTime());
+
+        const exampleBucketCache = createBucketCache(mockConnection, currentTime, tenMinutesAgo);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.checkCacheTimeout(10, 10, false);
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (!updatedCache) {
+            throw new Error("updatedCache is undefined");
+        }
+
+        const updatedScopeCache = updatedCache.scopes.get("exampleScope");
+        if (!updatedScopeCache) {
+            throw new Error("exampleScopeCache is undefined");
+        }
+
+        const updatedCollectionCache =
+            updatedScopeCache.collections.get("exampleCollection");
+        if (!updatedCollectionCache) {
+            throw new Error("updatedCollectionCache is undefined");
+        }
+
+        if (updatedCollectionCache.timeStamp) {
+            const collectionCacheTimeStamp = new Date(
+                updatedCollectionCache.timeStamp
+            );
+            expect(collectionCacheTimeStamp).not.toEqual(tenMinutesAgo);
+            expect(updatedCache.scopes.size).not.toEqual(2);
+        }
+    });
+
+    it("should correctly handle force refreshing of ONLY the bucket cache ", async () => {
+        // Time stamp, more than ten minutes
+        const tenMinutesAgo = new Date(new Date().getTime() - 15 * 60 * 1000);
+
+        const exampleBucketCache = createBucketCache(mockConnection, tenMinutesAgo, tenMinutesAgo);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.updateBucketCache("exampleBucket", true);
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is not equal to what it was 10minutes ago
+            expect(cacheTimeStamp).not.toEqual(tenMinutesAgo);
+        }
+    });
+
+    it("should correctly handle refreshing of ONLY the schema cache of a particular collection in a bucket ", async () => {
+        // Time stamp, more than ten minutes
+        const tenMinutesAgo = new Date(
+            new Date().getTime() - 15 * 60 * 1000
+        );
+
+        const exampleBucketCache = createBucketCache(mockConnection, tenMinutesAgo, tenMinutesAgo);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.updateCollectionSchemaCache(
+            mockConnection,
+            "exampleBucket",
+            "exampleScope",
+            "exampleCollection",
+            10,
+            false
+        );
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (!updatedCache) {
+            throw new Error("updatedCache is undefined");
+        }
+
+        const updatedScopeCache = updatedCache.scopes.get("exampleScope");
+        if (!updatedScopeCache) {
+            throw new Error("exampleScopeCache is undefined");
+        }
+
+        const updatedCollectionCache =
+            updatedScopeCache.collections.get("exampleCollection");
+        if (!updatedCollectionCache) {
+            throw new Error("updatedCollectionCache is undefined");
+        }
+
+        if (updatedCollectionCache.timeStamp) {
+            const collectionCacheTimeStamp = new Date(
+                updatedCollectionCache.timeStamp
+            );
+            expect(collectionCacheTimeStamp).not.toEqual(tenMinutesAgo);
+        }
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is equal to what it was 10minutes ago
+            expect(cacheTimeStamp).toEqual(tenMinutesAgo);
+        }
+    });
+
+    it("should correctly handle NOT refreshing of the schema cache of a particular collection in a bucket ", async () => {
+        // Time stamp, less than ten minutes
+        const currentTime = new Date(new Date().getTime() - 5 * 60 * 1000);
+
+        const exampleBucketCache = createBucketCache(mockConnection, currentTime, currentTime);
+
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.updateCollectionSchemaCache(
+            mockConnection,
+            "exampleBucket",
+            "exampleScope",
+            "exampleCollection",
+            10,
+            false
+        );
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (!updatedCache) {
+            throw new Error("updatedCache is undefined");
+        }
+
+        const updatedScopeCache = updatedCache.scopes.get("exampleScope");
+        if (!updatedScopeCache) {
+            throw new Error("exampleScopeCache is undefined");
+        }
+
+        const updatedCollectionCache =
+            updatedScopeCache.collections.get("exampleCollection");
+        if (!updatedCollectionCache) {
+            throw new Error("updatedCollectionCache is undefined");
+        }
+
+        if (updatedCollectionCache.timeStamp) {
+            const collectionCacheTimeStamp = new Date(
+                updatedCollectionCache.timeStamp
+            );
+            expect(collectionCacheTimeStamp).toEqual(currentTime);
+        }
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is equal to what it was previously as bucket cache is untouched
+            expect(cacheTimeStamp).toEqual(currentTime);
+        }
+    });
+
+    it("should correctly handle force refreshing of the schema cache of a particular collection in a bucket ", async () => {
+        // Time stamp, less than ten minutes
+        const currentTime = new Date(new Date().getTime() - 5 * 60 * 1000);
+
+        const exampleBucketCache = createBucketCache(mockConnection, currentTime, currentTime);
+
+        cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
+
+        await cacheService.updateCollectionSchemaCache(
+            mockConnection,
+            "exampleBucket",
+            "exampleScope",
+            "exampleCollection",
+            10,
+            true
+        );
+        const updatedCache = cacheService.getBucketData("exampleBucket");
+
+        if (!updatedCache) {
+            throw new Error("updatedCache is undefined");
+        }
+
+        const updatedScopeCache = updatedCache.scopes.get("exampleScope");
+        if (!updatedScopeCache) {
+            throw new Error("exampleScopeCache is undefined");
+        }
+
+        const updatedCollectionCache =
+            updatedScopeCache.collections.get("exampleCollection");
+        if (!updatedCollectionCache) {
+            throw new Error("updatedCollectionCache is undefined");
+        }
+
+        if (updatedCollectionCache.timeStamp) {
+            const collectionCacheTimeStamp = new Date(
+                updatedCollectionCache.timeStamp
+            );
+            expect(collectionCacheTimeStamp).not.toEqual(currentTime);
+        }
+        if (updatedCache && updatedCache.timeStamp) {
+            const cacheTimeStamp = exampleBucketCache?.timeStamp
+                ? new Date(updatedCache.timeStamp)
+                : new Date();
+            // Assert that cacheAgeMinutes is equal to what it was previously as bucket cache is untouched
+            expect(cacheTimeStamp).toEqual(currentTime);
+        }
+    });
+});

--- a/src/util/cacheService/cacheService.test.ts
+++ b/src/util/cacheService/cacheService.test.ts
@@ -124,7 +124,7 @@ describe("Given CacheService is responsible for refreshing the caching of couchb
         const exampleBucketCache = createBucketCache(mockConnection, tenMinutesAgo, tenMinutesAgo);
         // Helper method to set this.BucketsData 
         cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
-        await cacheService.checkCacheTimeout(10, 10, false);
+        await cacheService.refreshCacheOnTimeout(10, 10, false);
         // Helper method to get this.BucketsData
         const updatedCache = cacheService.getBucketData("exampleBucket");
         if (updatedCache && updatedCache.timeStamp) {
@@ -144,7 +144,7 @@ describe("Given CacheService is responsible for refreshing the caching of couchb
 
         cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
 
-        await cacheService.checkCacheTimeout(10, 10, false);
+        await cacheService.refreshCacheOnTimeout(10, 10, false);
         const updatedCache = cacheService.getBucketData("exampleBucket");
 
         if (updatedCache && updatedCache.timeStamp) {
@@ -164,7 +164,7 @@ describe("Given CacheService is responsible for refreshing the caching of couchb
 
         cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
 
-        await cacheService.checkCacheTimeout(10, 10, false);
+        await cacheService.refreshCacheOnTimeout(10, 10, false);
         const updatedCache = cacheService.getBucketData("exampleBucket");
 
         if (updatedCache && updatedCache.timeStamp) {
@@ -186,7 +186,7 @@ describe("Given CacheService is responsible for refreshing the caching of couchb
 
         cacheService.updateBucketsData("exampleBucket", exampleBucketCache);
 
-        await cacheService.checkCacheTimeout(10, 10, false);
+        await cacheService.refreshCacheOnTimeout(10, 10, false);
         const updatedCache = cacheService.getBucketData("exampleBucket");
 
         if (!updatedCache) {

--- a/src/util/cacheService/cacheService.ts
+++ b/src/util/cacheService/cacheService.ts
@@ -176,15 +176,10 @@ export class CacheService {
         }
     };
 
-
-
-
     //Refreshes the cache for all buckets if they are older than timeout or force refresh or not present in the cache
     private refreshBucketCache = async (connection: IConnection, bucketTimeOut: number, forceRefresh: boolean) => {
         try {
             const buckets = await connection.cluster?.buckets().getAllBuckets();
-
-
             if (!buckets) {
                 logger.debug("Error while fetching buckets and returned undefined");
                 return;
@@ -241,7 +236,7 @@ export class CacheService {
 
 
     // Checks and refreshes the cache for timeout.If the cache is loaded successfully, it refreshes the cache by updating bucket and collection cache if required
-    public checkCacheTimeout = async (bucketTimeOut: number, collectionTimeout: number, forceRefresh: boolean) => {
+    public refreshCacheOnTimeout = async (bucketTimeOut: number, collectionTimeout: number, forceRefresh: boolean) => {
 
         const connection = getActiveConnection();
         if (connection) {
@@ -255,14 +250,11 @@ export class CacheService {
                 await this.fullCache(true);
             }
         }
-
-
-
     }
 
 
     // Refreshes the index and schema cache for a single collection if necessary
-    private refreshCollectionSchemaCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, collectionTimeout: number, forceRefresh: boolean, result?: QueryResult<any>) => {
+    private refreshCollectionSchemaCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, collectionTimeout: number, forceRefresh: boolean, queryResult?: QueryResult<any>) => {
         const currentTimestamp = new Date();
         if (this.cacheStatus === false) {
             return undefined;
@@ -299,7 +291,7 @@ export class CacheService {
 
         if (minsDifference > collectionTimeout || minsDifference === 0 || forceRefresh) {
             if (hasQueryService(connection.services)) {
-                await this.cacheSchemaForCollection(connection, collectionData, result);
+                await this.cacheSchemaForCollection(connection, collectionData, queryResult);
             }
         }
 

--- a/src/util/cacheService/cacheService.ts
+++ b/src/util/cacheService/cacheService.ts
@@ -4,6 +4,8 @@ import { getActiveConnection } from "../connections";
 import { hasQueryService } from "../common";
 import { Global } from "../util";
 import { QueryIndex } from "couchbase";
+import { QueryResult } from "couchbase";
+import { CouchbaseError } from 'couchbase'
 
 export type SchemaCacheType = { [index: string]: any };
 export interface ISchemaCache {
@@ -16,6 +18,7 @@ export interface ICollectionCache {
     bucketName: string;
     schema?: ISchemaCache;
     indexes?: string[];
+    timeStamp?: Date;
 }
 
 export interface IScopeCache {
@@ -28,6 +31,7 @@ export interface IBucketCache {
     scopes: Map<string, IScopeCache>;
     name: string;
     connection: IConnection;
+    timeStamp: Date;
 }
 
 export class CacheService {
@@ -75,11 +79,13 @@ export class CacheService {
         return currentNodes;
     }
 
-    public cacheSchemaForCollection = async (connection: IConnection, collection: ICollectionCache) => {
-        try {
-            const query = "INFER `" + collection.bucketName + "`.`" + collection.scopeName + "`.`" + collection.name + "` WITH {\"sample_size\": 2000}";
-            const result = await connection?.cluster?.query(query);
 
+    public cacheSchemaForCollection = async (connection: IConnection, collection: ICollectionCache, result?: QueryResult<any>) => {
+        try {
+            if (!result) {
+                const query = "INFER `" + collection.bucketName + "`.`" + collection.scopeName + "`.`" + collection.name + "` WITH {\"sample_size\": 2000}";
+                result = await connection?.cluster?.query(query);
+            }
             const patternCnt: number = result?.rows[0].length || 0;
             const schemaPatternData: SchemaCacheType[] = [];
             for (let i = 0; i < patternCnt; i++) {
@@ -88,16 +94,25 @@ export class CacheService {
                 schemaPatternData.push(childrenNode);
             }
             collection.schema = { patterns: schemaPatternData };
-        } catch (error) {
+            collection.timeStamp = new Date();
+        } catch (error: any) {
+            if (error instanceof CouchbaseError && (error as any).cause?.first_error_code === 7014) {
+                collection.schema = { patterns: [] };
+                collection.timeStamp = new Date();
+                logger.debug(`No documents found, unable to infer schema for a collection: ${collection.bucketName}.${collection.scopeName}.${collection.name}, error: ${error}`);
+            }
             logger.error(`error while caching schema for a collection: ${collection.bucketName}.${collection.scopeName}.${collection.name}, error: ${error}`);
         }
     };
 
-    public async cacheIndexesForCollection(connection: IConnection, collection: ICollectionCache): Promise<QueryIndex[]> {
-        const indexesResult = await connection?.cluster?.queryIndexes().getAllIndexes(collection.bucketName, { scopeName: collection.scopeName, collectionName: collection.name });
+    public async cacheIndexesForCollection(connection: IConnection, collection: ICollectionCache, indexesResult?: QueryIndex[]): Promise<QueryIndex[]> {
+        if (!indexesResult) {
+            indexesResult = await connection?.cluster?.queryIndexes().getAllIndexes(collection.bucketName, { scopeName: collection.scopeName, collectionName: collection.name });
+        }
         collection.indexes = indexesResult?.map((index) => {
             return JSON.stringify(index);
         });
+        collection.timeStamp = new Date();
         return indexesResult || [];
     }
 
@@ -106,61 +121,327 @@ export class CacheService {
         for (let [_, bucket] of this.bucketsData) {
             for (let [_, scope] of bucket.scopes) {
                 for (let [_, collection] of scope.collections) {
-                    const indexes = await this.cacheIndexesForCollection(connection, collection);
-                    if (indexes.length > 0) { // Only cache schema 
-                        await this.cacheSchemaForCollection(connection, collection);
-                    }
+                    await this.cacheIndexesForCollection(connection, collection);
+                    await this.cacheSchemaForCollection(connection, collection);
                 };
             };
         };
         logger.info("caching of schema for all buckets done");
     };
 
-    // This function focuses on caching the scopes and collections data for one particular bucket
-    public cacheBucket = async (connection: IConnection, bucketName: string) => {
-        const scopesData: Map<string, IScopeCache> = new Map();
-        let scopes = await connection.cluster
-            ?.bucket(bucketName)
-            .collections()
-            .getAllScopes();
-        if (scopes) {
-            for (let scope of scopes) {
-                const collectionsData: Map<string, ICollectionCache> = new Map();
-                for await (let collection of scope.collections) {
-                    collectionsData.set(collection.name, {
-                        name: collection.name,
-                        scopeName: scope.name,
-                        bucketName: bucketName
-                    });
-                };
 
-                scopesData.set(scope.name, {
-                    collections: collectionsData,
-                    name: scope.name,
-                    bucketName: bucketName
+    private cacheBucket = async (connection: IConnection, bucketName: string) => {
+        try {
+            const currentTimestamp = new Date();
+            const scopesData: Map<string, IScopeCache> = new Map();
+            const scopes = await connection.cluster
+                ?.bucket(bucketName)
+                .collections()
+                .getAllScopes();
+            if (scopes) {
+                const existingBucketData = this.bucketsData.get(bucketName);
+                const existingScopes = existingBucketData ? existingBucketData.scopes : new Map<string, IScopeCache>();
+                for (const scope of scopes) {
+                    const collectionsData: Map<string, ICollectionCache> = new Map();
+                    const existingScope = existingScopes.get(scope.name);
+
+                    for (const collection of scope.collections) {
+                        const existingCollection = existingScope ? existingScope.collections.get(collection.name) : undefined;
+                        collectionsData.set(collection.name, {
+                            name: collection.name,
+                            scopeName: scope.name,
+                            bucketName: bucketName,
+                            schema: existingCollection ? existingCollection.schema : undefined,
+                            indexes: existingCollection ? existingCollection.indexes : undefined,
+                            timeStamp: existingCollection ? existingCollection.timeStamp : currentTimestamp,
+                        });
+                    }
+
+                    scopesData.set(scope.name, {
+                        collections: collectionsData,
+                        name: scope.name,
+                        bucketName: bucketName,
+                    });
+                }
+
+                this.bucketsData.set(bucketName, {
+                    scopes: scopesData,
+                    name: bucketName,
+                    connection: connection,
+                    timeStamp: currentTimestamp,
                 });
-            };
-            this.bucketsData.set(bucketName, {
-                scopes: scopesData,
-                name: bucketName,
-                connection: connection
-            });
+            }
+        } catch (error) {
+            logger.error(`Error while caching bucket '${bucketName}': ${error}`);
         }
     };
+
+
+
+
+    //Refreshes the cache for all buckets if they are older than timeout or force refresh or not present in the cache
+    private refreshBucketCache = async (connection: IConnection, bucketTimeOut: number, forceRefresh: boolean) => {
+        try {
+            const buckets = await connection.cluster?.buckets().getAllBuckets();
+
+
+            if (!buckets) {
+                logger.debug("Error while fetching buckets and returned undefined");
+                return;
+            }
+
+            const currentTimestamp = new Date();
+
+            for (const bucket of buckets) {
+                const cachedBucket = this.bucketsData.get(bucket.name);
+                const bucketExistsInCache = !!cachedBucket;
+                if (!bucketExistsInCache) {
+                    await this.cacheBucket(connection, bucket.name);
+                } else {
+                    const bucketTimestamp = new Date(cachedBucket.timeStamp);
+                    const timeDifferenceMinutes = (currentTimestamp.getTime() - bucketTimestamp.getTime()) / (1000 * 60);
+                    if (timeDifferenceMinutes > bucketTimeOut || forceRefresh) {
+                        await this.cacheBucket(connection, bucket.name);
+                    } else {
+                        logger.info(`Bucket '${bucket.name}' cache timestamp within threshold minutes, no update needed.`);
+                    }
+                }
+            }
+        } catch (error) {
+            logger.error("Error while refreshing bucket cache" + error);
+        }
+    }
+
+
+    // Refreshes the cache by updating bucket and collection cache if timestamps are older than timeouts specified/ force refresh is true
+    private refreshCache = async (connection: IConnection, bucketTimeOut: number, collectionTimeout: number, forceRefresh: boolean) => {
+        try {
+            await this.refreshBucketCache(connection, bucketTimeOut, forceRefresh);
+            this.cacheStatus = true;
+            await this.refreshOutdatedCollections(connection, collectionTimeout, forceRefresh);
+
+        } catch (error) {
+            logger.error("Error while refreshing cache" + error);
+        }
+    };
+
+    // Refreshes the outdated collection cache if timestamps are older than timeouts specified/ force refresh is true
+    private async refreshOutdatedCollections(connection: IConnection, collectionTimeout: number, forceRefresh: boolean) {
+        for (const [_, bucket] of this.bucketsData) {
+            for (const [_, scope] of bucket.scopes) {
+                for (const [_, collection] of scope.collections) {
+                    await this.refreshCollectionSchemaCache(connection, collection.bucketName, collection.scopeName, collection.name, collectionTimeout, forceRefresh);
+                    if (forceRefresh) {
+                        await this.refreshCollectionIndexCache(connection, collection.bucketName, collection.scopeName, collection.name);
+                    }
+                }
+            }
+        }
+    }
+
+
+    // Checks and refreshes the cache for timeout.If the cache is loaded successfully, it refreshes the cache by updating bucket and collection cache if required
+    public checkCacheTimeout = async (bucketTimeOut: number, collectionTimeout: number, forceRefresh: boolean) => {
+
+        const connection = getActiveConnection();
+        if (connection) {
+            const isCacheSuccessful = await this.loadCache(connection);
+            if (isCacheSuccessful) {
+                await this.refreshCache(connection, bucketTimeOut, collectionTimeout, forceRefresh);
+                this.cacheStatus = true;
+                await this.storeCache(connection);
+            }
+            else {
+                await this.fullCache(true);
+            }
+        }
+
+
+
+    }
+
+
+    // Refreshes the index and schema cache for a single collection if necessary
+    private refreshCollectionSchemaCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, collectionTimeout: number, forceRefresh: boolean, result?: QueryResult<any>) => {
+        const currentTimestamp = new Date();
+        if (this.cacheStatus === false) {
+            return undefined;
+        }
+
+        const bucketCache = this.bucketsData.get(bucketName);
+        if (!bucketCache) {
+            return undefined;
+        }
+
+
+        const scopeData = bucketCache.scopes.get(scopeName);
+        if (scopeData === undefined) {
+            return undefined;
+        }
+
+        const collectionData = scopeData.collections.get(collectionName);
+        if (collectionData === undefined) {
+            return undefined;
+        }
+
+
+
+        if (!collectionData.timeStamp) {
+            collectionData.timeStamp = currentTimestamp;
+        }
+
+        const collectionTimestamp = new Date(collectionData.timeStamp);
+        let minsDifference = 0
+        const difference = currentTimestamp.getTime() - collectionTimestamp.getTime();
+        if (difference != 0) {
+            minsDifference = difference / (1000 * 60);
+        }
+
+        if (minsDifference > collectionTimeout || minsDifference === 0 || forceRefresh) {
+            if (hasQueryService(connection.services)) {
+                await this.cacheSchemaForCollection(connection, collectionData, result);
+            }
+        }
+
+    }
+
+    // Refreshes the index cache for a single collection
+    private refreshCollectionIndexCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, indexesResult?: QueryIndex[]) => {
+        if (this.cacheStatus === false) {
+            return undefined;
+        }
+        const bucketCache = this.bucketsData.get(bucketName);
+        if (!bucketCache) {
+            return undefined;
+        }
+
+        const scopeData = bucketCache.scopes.get(scopeName);
+        if (scopeData === undefined) {
+            return undefined;
+        }
+
+        const collectionData = scopeData.collections.get(collectionName);
+        if (collectionData === undefined) {
+            return undefined;
+        }
+        if (hasQueryService(connection.services)) {
+            const indexes = await this.cacheIndexesForCollection(connection, collectionData, indexesResult);
+        }
+    }
+
+    // Updates the Bucket cache if required
+    public updateBucketCache = async (bucketName: string, forceRefresh: boolean) => {
+        const connection = getActiveConnection();
+        if (connection) {
+            const isCacheSuccessful = await this.loadCache(connection);
+            if (isCacheSuccessful) {
+                if (forceRefresh) {
+                    await this.cacheBucket(connection, bucketName);
+                    this.cacheStatus = true;
+                    await this.storeCache(connection);
+                }
+            }
+            else {
+                await this.fullCache(true);
+            }
+        }
+    }
+
+
+    // Updates the Index cache for a particular collection if required
+    public updateCollectionIndexCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, indexesResult?: QueryIndex[]) => {
+        if (this.cacheStatus === false) {
+            return undefined;
+        }
+        if (connection) {
+            const isCacheSuccessful = await this.loadCache(connection);
+            if (isCacheSuccessful) {
+                await this.refreshCollectionIndexCache(connection, bucketName, scopeName, collectionName, indexesResult);
+                await this.storeCache(connection);
+            }
+            else {
+                await this.fullCache(true);
+            }
+
+        }
+
+    }
+
+    // Updates the Schema cache for a particular collection if required
+    public updateCollectionSchemaCache = async (connection: IConnection, bucketName: string, scopeName: string, collectionName: string, collectionTimeout: number, forceRefresh: boolean, queryResult?: QueryResult<any>) => {
+        if (this.cacheStatus === false) {
+            return undefined;
+        }
+        if (connection) {
+            const isCacheSuccessful = await this.loadCache(connection);
+            if (isCacheSuccessful) {
+                await this.refreshCollectionSchemaCache(connection, bucketName, scopeName, collectionName, collectionTimeout, forceRefresh, queryResult);
+                await this.storeCache(connection);
+            }
+            else {
+                await this.fullCache(true);
+            }
+
+        }
+    }
+
+    // Updates the Index cache and Schema cache for a particular collection if required
+    public async updateCollectionSchemaAndIndexCache(connection: IConnection, bucketName: string, scopeName: string, collectionName: string, collectionTimeout: number, forceRefresh: boolean, result?: QueryResult<any>, indexesResult?: QueryIndex[]) {
+        if (this.cacheStatus === false) {
+            return undefined;
+        }
+        if (connection) {
+            const isCacheSuccessful = await this.loadCache(connection);
+            if (isCacheSuccessful) {
+                await this.refreshCollectionSchemaCache(connection, bucketName, scopeName, collectionName, collectionTimeout, forceRefresh);
+                if (forceRefresh) {
+                    await this.refreshCollectionIndexCache(connection, bucketName, scopeName, collectionName, indexesResult);
+                }
+                await this.storeCache(connection);
+            }
+            else {
+                await this.fullCache(true);
+            }
+        }
+    }
+
+    // Clears the existing cache from memory and does a full cache
+    public async clearAndRefreshCache(connection: IConnection, forceRefresh: boolean) {
+        if (connection) {
+            Global.state.update(`vscode-couchbase.iq.bucketsCache.${connection.connectionIdentifier}`, "");
+            this.bucketsData.clear();
+            await this.fullCache(true);
+
+        }
+
+    }
+
+    public updateBucketsData(bucketName: string, bucket: IBucketCache) {
+        this.bucketsData.clear();
+        this.cacheStatus = true;
+        this.bucketsData.set(bucketName, bucket);
+    }
+
+    public getBucketData(bucketName: string): IBucketCache | undefined {
+        return this.bucketsData.get(bucketName);
+    }
+
 
     // This function focuses on caching the scopes and collections data for each bucket
     public cacheAllBuckets = async (connection: IConnection) => {
         this.bucketsData = new Map(); // Remove any existing cache
+
         try {
             let buckets = await connection.cluster?.buckets().getAllBuckets();
+
             if (buckets === undefined) {
                 logger.debug("Error while fetching buckets and returned undefined");
                 return;
             }
+
             for await (let bucket of buckets) {
                 await this.cacheBucket(connection, bucket.name);
-            };
-
+            }
         } catch (error) {
             logger.error("Error while caching all collections " + error);
         }
@@ -212,6 +493,8 @@ export class CacheService {
         return collectionData;
 
     };
+
+
 
     public getCollectionWithScopeName = async (scopeName: string, collectionName: string): Promise<undefined | ICollectionCache> => {
         if (this.cacheStatus === false) {
@@ -279,6 +562,7 @@ export class CacheService {
                 name: bucket.name,
                 scopes: {},
                 connection: bucket.connection, // Assume serializable
+                timeStamp: bucket.timeStamp
             };
             // Serialize each scope in the bucket's map
             for (const [scopeName, scope] of bucket.scopes) {
@@ -294,7 +578,8 @@ export class CacheService {
                         schema: collection.schema ? this.serializeSchema(collection.schema) : undefined,
                         scopeName: scopeName,
                         bucketName: bucketName,
-                        indexes: collection.indexes
+                        indexes: collection.indexes,
+                        timeStamp: collection.timeStamp,
                     };
                 }
             }
@@ -305,7 +590,7 @@ export class CacheService {
         // return vscode.globalState.update(BUCKETS_STATE_KEY, finalJson);
     }
 
-    private async loadCache(connection: IConnection): Promise<boolean> {
+    public async loadCache(connection: IConnection): Promise<boolean> {
         const storedDataJson = Global.state.get<string>(`vscode-couchbase.iq.bucketsCache.${connection.connectionIdentifier}`);
         if (!storedDataJson) {
             return false; // No existing cache
@@ -318,6 +603,7 @@ export class CacheService {
                 name: storedData[bucketName].name,
                 connection: storedData[bucketName].connection, // Assume deserializable
                 scopes: new Map(),
+                timeStamp: storedData[bucketName].timeStamp,
             };
             this.bucketsData.set(bucketName, bucket);
             logger.info("loading cache from bucket: " + bucketName);
@@ -338,7 +624,8 @@ export class CacheService {
                             : undefined,
                         indexes: storedData[bucketName].scopes[scopeName].collections[collectionName].indexes,
                         scopeName: scopeName,
-                        bucketName: bucketName
+                        bucketName: bucketName,
+                        timeStamp: storedData[bucketName].scopes[scopeName].collections[collectionName].timeStamp,
                     };
                     scope.collections.set(collectionName, collection);
                 }

--- a/src/util/connections.ts
+++ b/src/util/connections.ts
@@ -138,6 +138,8 @@ export async function addConnection(clusterConnectionTreeProvider: ClusterConnec
         }
         clusterConnectionTreeProvider.refresh();
         currentPanel.dispose();
+        // Do a full cache for the first time user creates connection
+        clusterConnectionTreeProvider.cacheService.fullCache(true);
         logger.info(`Successfully saved a new connection with the name ${connection.connectionIdentifier}`);
         break;
 

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -84,6 +84,8 @@ export class Constants {
   public static SWAP_USED = "Swap Used";
   public static CORES_AVAILABLE = "Cores Available";
   public static CPU_STOLE_RATE = "CPU Stole Rate";
+  public static BUCKET_CACHE_EXPIRY_DURATION = 10;
+  public static COLLECTION_CACHE_EXPIRY_DURATION = 10;
   public static DOCUMENTS_DATA_SIZE = "Documents Data Size";
   public static DOCUMENTS_DATA_SIZE_ON_DISK = "Documents Data Size on Disk";
   public static SPATIAL_DATA_SIZE = "Spatial Data Size";

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -84,8 +84,8 @@ export class Constants {
   public static SWAP_USED = "Swap Used";
   public static CORES_AVAILABLE = "Cores Available";
   public static CPU_STOLE_RATE = "CPU Stole Rate";
-  public static BUCKET_CACHE_EXPIRY_DURATION = 10;
-  public static COLLECTION_CACHE_EXPIRY_DURATION = 10;
+  public static BUCKET_CACHE_EXPIRY_DURATION = 3 * 24 * 60;
+  public static COLLECTION_CACHE_EXPIRY_DURATION = 24 * 60;
   public static DOCUMENTS_DATA_SIZE = "Documents Data Size";
   public static DOCUMENTS_DATA_SIZE_ON_DISK = "Documents Data Size on Disk";
   public static SPATIAL_DATA_SIZE = "Spatial Data Size";
@@ -98,6 +98,7 @@ export class Constants {
   public static HITS = "Hits";
   public static INDEX_DATA_SIZE = "Index Data Size";
   public static INDEX_DATA_SIZE_ON_DISK = "Index Data Size on Disk";
+  public static INFER_SAMPLE_SIZE = 2000;
   public static OPS = "Ops";
   public static CURRENT_VBUCKET_REPLICA_ITEMS = "Current vBucket Replica Items";
   public static QUERY_RESULT = "Couchbase Query Result";

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -37,8 +37,9 @@ class LocalState {
     return;
   }
   update(key: string, value: any): Thenable<void> {
-    return new Promise(() => {
+    return new Promise((resolve) => {
       this.state[key] = value;
+      resolve();
     });
   }
 }

--- a/src/webViews/tools/mdbMigrate.webview.ts
+++ b/src/webViews/tools/mdbMigrate.webview.ts
@@ -485,9 +485,7 @@ function submitForm(event) {
     event.preventDefault(); // Prevent the form from submitting in the traditional way
     document.getElementById("validation-error").innerHTML = "";
     // Gather data from form fields
-    const connectionString = document.getElementById(
-        "mongoConnectionString"
-    ).value;
+    const connectionString = "'" + document.getElementById("mongoConnectionString").value + "'";
     const database = document.getElementById("databases").value;
     const collections = getSelectedCollections();
     const indexesCheckbox = document.getElementById("indexes");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
This PR majorly updates the Cache service and tree nodes with the following:

- Updates the cache service to handle refresh of cache when required.
- Update the tree nodes to refresh each time user clicks on the node(previously used to fetch from vs code builtin cache).
- Basic tests for refresh cache.
- Fixes the mongoDB Migrate URI bug.
